### PR TITLE
The heat model gets the same dt guard as everything else (#12)

### DIFF
--- a/.seed-report.md
+++ b/.seed-report.md
@@ -1,0 +1,252 @@
+# Seeded, shareable runs — build report
+
+Branch `feat/seeded-runs`. Baseline confirmed before starting: lint clean,
+23 test files, 445 tests. Final: lint clean, **26 test files, 503 tests**
+(+58), about 3 s. **No campaign pair moved** — all 445 pre-existing tests
+pass untouched, including every winnable-with / losable-without pair.
+
+---
+
+## Per-file changes
+
+| File | Change |
+|---|---|
+| `src/core/rng.js` | **NEW.** mulberry32, FNV-1a `hash32`, `normalizeSeed`, `randomSeedToken(pick)`, `seededRngs(seed)`. Pure: no DOM, no timers, no `Math.random` — entropy is injected into `randomSeedToken`, and `seededRngs` returns `null` rather than manufacturing a fallback. Knows nothing about URLs. |
+| `src/core/state.js` | `STATE.seed` (the normalized token or `null`), plus the matching fresh literal in `resetState()`. A token, never a generator — ARCHITECTURE forbids an rng in STATE. |
+| `game.js` | Composition root. Reads `?seed=` off `location.search`, arms the run (`armRun`), threads `runRng.crisis` / `runRng.contracts` into the two ticks, keeps the address bar in sync (`history.replaceState`), and owns `window.rollSeed` / `window.copySeedLink`. `startGame(seed)` overload: `undefined` = read the menu box, explicit value (incl. `null`) wins — which is how Restart and Retry replay the *same* room. Boot auto-starts a run when the URL carries a seed. |
+| `src/ui/hud.js` | `shareUrl(seed)` (null when unseeded), the seed pill in `tickHud`, and `renderShare()` on the game-over screen. Reads STATE, writes DOM — the boundary is intact. |
+| `index.html` | Seed pill (`<button>`, inline SVG die, no emoji), the menu's seed box + roll button + hint line, and the game-over share row (readonly URL field + copy button). |
+| `src/locales/en.js`, `src/locales/uk.js` | Eight new keys each, identical sets. |
+| `tests/seeded-run.test.mjs` | **NEW**, node tier, 25 tests: the generator, the token rules, stream independence, the 240 s determinism signature, divergence across five seeds, inertness, source-level purity, and "the campaign draws zero". |
+| `tests/sim/seed-wiring.test.mjs` | **NEW**, sim tier, 18 tests. Drives the **shipped `game.js`** by capturing its `requestAnimationFrame` callback before import and stepping it at a fixed 50 ms — real loop, real tick order, real wiring. |
+| `tests/sim/seed-hud.test.mjs` | **NEW**, sim tier, 15 tests: pill, share URL, game-over row, both locales, against the real `index.html` DOM. |
+| `README.md` | A bullet on shareable runs; status count 445 → 503. |
+| `CONTRIBUTING.md` | Baseline line: 23 files/445 tests → 26/503. |
+
+Not touched: any sim module, any CONFIG value, any level, the tick order.
+
+## The PRNG and the encoding
+
+**mulberry32.** 32-bit state, one multiply-xorshift round per draw, full 2^32
+period, ~6 lines, no dependency (this repo has no build step and should not
+grow one for six lines). `tickCrisis`/`tickContracts` already accept an
+injected rng; the only thing missing was something to inject.
+
+**Two streams, not one.** `crisis` and `contracts` are separate generators,
+salted apart (`hash32("crisis:" + token)` vs `hash32("contracts:" + token)`).
+With one shared generator each subsystem's sequence would depend on how many
+draws the *other* one happened to take, so adding a crisis event later would
+silently re-roll every contract of every existing seed. Pinned by a test that
+advances the crisis stream 37 draws and asserts the contract stream did not
+move.
+
+**The seed is a short uppercase alphanumeric token, and the token *is* the
+identity.** `normalizeSeed` = uppercase → strip to `[0-9A-Z]` → cap at 12.
+Idempotent by construction, so pill, address bar and share link all round-trip
+with no special cases (`normalizeSeed(normalizeSeed(x)) === normalizeSeed(x)`,
+asserted). The PRNG state is `hash32(salt + token)`, so a word works as well
+as a code: `?seed=kyiv` is a legal room and displays as `KYIV`.
+
+Generated seeds are **5 characters of Crockford base32 minus the
+confusables** — `0123456789ABCDEFGHJKMNPQRSTVWXYZ`, no `I`/`L`/`O` (misread as
+1/1/0) and no `U` (so a random seed cannot spell something unfortunate). 32^5
+≈ 33.5 million rooms: short enough to read down a phone line, wide enough that
+two people comparing runs are comparing the same one. Deliberately not a UUID
+and not base64 (case-sensitive, `+/=` are URL and chat hazards).
+
+Input is *not* confusable-folded (`O` → `0`), because that would mangle word
+seeds — `KYIV` would become `KY1V`. The generated alphabet avoids the
+ambiguity at the source instead, which is the half we control.
+
+## Design judgement 1 — the tutorial
+
+**Decision: a seeded run does not offer the tutorial, and does not touch the
+saved tutorial flag.**
+
+The tutorial is not cosmetic to a run's starting conditions: game time is
+frozen while it runs (`game.js:50`) but `dt` still flows, so racks earn and
+gear gets built before the clock starts. A tutorial'd run and a skipped one
+are not the same room at t=0 — and "same seed, same run" has to mean the room,
+not only the crises. So `startGame` shows the ceremony only when
+`STATE.seed === null`.
+
+The other half is the restraint: it does **not** write `dc_tutorial_done`.
+Pinning first-run state by mutating the recipient's profile means a link
+somebody sent you silently rewrites what you have already learned. A shared
+link may decide what *this run* looks like; it may not decide what your save
+file says. Three tests pin all of it, including that an *unseeded* first run
+still gets the ceremony — the seed did not steal the tutorial from anyone.
+
+## Design judgement 2 — the campaign
+
+**Decision: the campaign takes no seed. Checked, not assumed — and the check
+is now a test.**
+
+`startLevelState` (`src/campaign/campaign.js:157-163`) pins `heatwave`,
+`brownout`, `breakdown`, `gridOutage`, `tariff`, `drought` and `contract`
+`nextAt` to `Infinity`. Both consumers only draw when a schedule is `null`
+(first-tick draw) or `elapsed >= nextAt` — neither can ever be true at
+`Infinity`. `tickEvents` (heatwave) and the demand curve are pure functions of
+the clock, and `src/ui/pulses.js` is the only other `Math.random` in the repo
+(cosmetic wire particles, not sim). So a seed in a campaign level would draw
+nothing: decoration.
+
+The test does not assert my reading, it measures it: a counting rng over
+**every level in `levelOrder()`** for 30 s each records exactly zero calls —
+next to a **control** on the same loop that shows a survival room consuming
+both streams within one tick, so the zero cannot be vacuous. `game.js`
+therefore clears the seed on every `beginRun()`, and a campaign level never
+re-arms it: the pill can never lie about a run that has no randomness in it.
+
+## What goes in the shareable text
+
+**The link, and nothing else.** The game-over screen shows the seed, a
+selectable URL field and a copy button, sitting above the loss ledger and
+below the stats it always had. No pasted score string: "4:12, PUE 1.19" is
+exactly the unfalsifiable claim this feature exists to replace, the numbers
+are already on the screen, and the URL is the half that lets somebody check
+them. There is no backend and there will not be one — the scoreboard is two
+people playing the same room. The pill is copyable mid-run for the same
+reason.
+
+## Mutation testing
+
+Nine mutations, each applied to the real source, suite run, reverted
+(`scratchpad/mutate.py`, backup-and-restore; the tree was verified clean
+afterwards and the suite re-run green). Command per mutation:
+`npx vitest run 2>&1 | grep -E '^\s+(×|Tests|Test Files)' | sort -u`.
+
+```
+=== M1: seed parsed but IGNORED — the run is still Math.random ===
+      Tests  8 failed | 495 passed (503)
+     × Restart replays the SAME room — not a fresh roll of the dice 9ms
+     × Retry from the pause menu replays it too 30ms
+     × a seed makes crisis and contracts INDEPENDENT: one drawing more never moves the other 11ms
+     × consumes ONE continuous stream: the exact numbers the seed promises, in the order it promises them 1ms
+     × reaches the same room from the URL a player would paste, however they typed it 157ms
+     × replays a 240 s run tick for tick — schedules, windows, contracts, money 410ms
+     × the only Math.random in the pure layer is the injected default in a signature 6ms
+     × the same seed schedules the same run 20ms
+ Test Files  2 failed | 24 passed (26)
+
+=== M2: ONE rng instance shared by both consumers ===
+      Tests  2 failed | 501 passed (503)
+     × a seed makes crisis and contracts INDEPENDENT: one drawing more never moves the other 8ms
+     × consumes ONE continuous stream: the exact numbers the seed promises, in the order it promises them 9ms
+ Test Files  2 failed | 24 passed (26)
+
+=== M3: two instances, SAME salt — two streams that are secretly one ===
+      Tests  1 failed | 502 passed (503)
+     × and they are genuinely two — the same seed does not hand both the same numbers 6ms
+ Test Files  1 failed | 25 passed (26)
+
+=== M4: seed NOT threaded to tickCrisis ===
+      Tests  4 failed | 499 passed (503)
+     × Restart replays the SAME room — not a fresh roll of the dice 56ms
+     × Retry from the pause menu replays it too 11ms
+     × draws every schedule from the seed — the test that catches one unthreaded tick 18ms
+     × the same seed schedules the same run 10ms
+ Test Files  1 failed | 25 passed (26)
+
+=== M5: seed NOT threaded to tickContracts ===
+      Tests  5 failed | 498 passed (503)
+     × Restart replays the SAME room — not a fresh roll of the dice 12ms
+     × Retry from the pause menu replays it too 26ms
+     × consumes ONE continuous stream: the exact numbers the seed promises, in the order it promises them 2ms
+     × draws every schedule from the seed — the test that catches one unthreaded tick 19ms
+     × the same seed schedules the same run 13ms
+ Test Files  1 failed | 25 passed (26)
+
+=== M6: a FRESH generator per tick — the stream restarts every frame ===
+      Tests  1 failed | 502 passed (503)
+     × consumes ONE continuous stream: the exact numbers the seed promises, in the order it promises them 5ms
+ Test Files  1 failed | 25 passed (26)
+
+=== M7: a seed goes STICKY — an unseeded run keeps the last one's stream ===
+      Tests  1 failed | 502 passed (503)
+     × an UNSEEDED run does use Math.random — the default was never taken away 4ms
+ Test Files  1 failed | 25 passed (26)
+
+=== M8: the token stops folding case — the pill no longer round-trips ===
+      Tests  5 failed | 498 passed (503)
+     × folds case and strips what a URL or a chat client would mangle 7ms
+     × puts the run on the address bar, so the address bar IS the share link 2ms
+     × reaches the same room from the URL a player would paste, however they typed it 1ms
+     × starts a run on the token the player typed, normalized 12ms
+     × takes it from the menu box when Power On is pressed with nothing else to go on 9ms
+ Test Files  2 failed | 24 passed (26)
+
+=== M9: a campaign level stops pinning its contract schedule ===
+      Tests  3 failed | 500 passed (503)
+     × and the level's schedules stay pinned out of reach, seed or no seed 33ms
+     × every campaign level draws ZERO random numbers over 30 s — a seed there would be decoration 24ms
+     × level start pins demand flat and freezes every random schedule 15ms
+ Test Files  3 failed | 23 passed (26)
+```
+
+Two notes on what these say:
+
+- **M6 (a generator rebuilt per tick) is caught by exactly one test, and it
+  had to be written for it.** A per-tick rebuild still *repeats* — it just
+  repeats the wrong run — so every "same seed, same run" assertion stays
+  green. Only checking the game's **third** draw against an independently
+  advanced copy of the seed's stream tells the two apart. That test is the
+  sharpest one in the suite and it also covers M1/M2/M5.
+- **M7 is caught by the Math.random spy, not by "two unseeded runs differ".**
+  A sticky stream keeps *advancing*, so two unseeded runs still differ; what
+  gives it away is that `Math.random` is never reached at all.
+
+## Browser verification
+
+Served at `http://localhost:8243` (port bumped in `.claude/launch.json` to
+bust the ES-module cache, **reverted before committing** — `git diff` on that
+file is empty).
+
+- `?seed=kyiv` → lands **in** the run (menu gone, paused, ready), pill reads
+  `SEED KYIV`, address bar canonicalized to `?seed=KYIV`.
+- Same seed loaded twice, Play pressed, schedules read out of the live
+  `STATE` module: `brownout 159.83247805…` / `159.83257805…`,
+  `breakdown 112.77353420…` / `112.77363420…`, `contract 69.07054035…` /
+  `69.07064035…` — every draw identical to twelve significant digits.
+- Roll button → `1021G`; Power On → seeded run, pill and `?seed=1021G`, no URL
+  editing anywhere.
+- Pill click → banner `Link copied — seed 1021G`.
+- Forced bankruptcy → game-over screen shows `SEND THIS LINK — THE SAME ROOM,
+  SEED KYIV` with `http://localhost:8243/?seed=KYIV` in a selectable field and
+  a copy button, above the existing ledger and beside the existing stats.
+- No seed → no pill, no `?seed` on the address bar, and the tutorial ceremony
+  **is** still offered on the same fresh profile the seeded run skipped it on;
+  `dc_tutorial_done` stayed `null` throughout.
+- Campaign level launched after a seeded run → seed `null`, pill hidden, every
+  schedule `Infinity`.
+- UK locale: `СІД (ЗА БАЖАННЯМ)` fits the box, the hint wraps cleanly.
+
+### One honest limit found in the browser
+
+The **draws** are identical; the **absolute clock** is not, to about 0.1 ms.
+A schedule is `elapsed + span(rng)`, and `elapsed` at the first tick is the
+first frame's real `dt`. Two loads therefore anchor the whole run a fraction
+of a millisecond apart, and the sim integrates at whatever frame rate the
+machine gives it. Which crisis, how long, which contract, what target — all
+identical. Fixing the anchor would mean changing the sim's scheduling
+semantics, which is exactly the kind of change the campaign proofs are there
+to stop. The test harness runs at fixed `dt` and reproduces runs exactly.
+
+## Concerns / things left alone
+
+- `src/ui/pulses.js:60` still calls `Math.random` for wire particles. It is a
+  UI module, outside the purity rule and outside the run — no sim state
+  depends on it. Seeding it would make screenshots identical too; I judged
+  that scope creep and left it, deliberately.
+- `dc_best_run` folds seeded runs in like any other. A seeded run is still a
+  run; unchanged behaviour, no new decision.
+- **Pre-existing doc drift I did not silently "fix":** ARCHITECTURE says the
+  tick loop is hand-copied into "nine test helpers (eleven copies)",
+  CONTRIBUTING says "ten" — they already disagreed with each other and with
+  the tree (14 files carried a copy before this branch; mine is the 15th).
+  Fixing that needs a judgement about what counts as a helper, so it is a
+  separate PR, not a guess buried in this one. CONTRIBUTING's *baseline*
+  (files/tests) was concretely moved by this change, so that one I updated.
+- The FAQ has no Seeds tab. The menu hint and the placeholder carry the
+  explanation today; a FAQ tab would be more i18n surface for the same
+  sentence.

--- a/.water-report.md
+++ b/.water-report.md
@@ -1,0 +1,336 @@
+# Water consumption and WUE — build report
+
+Branch `feat/water-wue`. Baseline at start: lint clean, 21 test files, **406
+tests**. At the end: lint clean, 23 test files, **445 tests** (+39).
+
+`npm run check` green before the commit.
+
+---
+
+## What shipped
+
+The chilled-water loop now pays for its cooling tower. Chapter 4's decision
+was two-dimensional — the loop is more efficient than CRACs at scale, and it
+concentrates the blast radius. Water is the third dimension, and it gives the
+plant an honest price it was not paying: an evaporative tower rejects heat by
+**boiling water off**, so the loop buys its power advantage with a running
+water bill that an air-cooled CRAC does not have at all. A **drought** prices
+that water past break-even, and for the length of the window the CRAC —
+strictly worse on power at every size — is the cheaper room.
+
+---
+
+## Per-file changes
+
+### Simulation
+
+| File | Change |
+|---|---|
+| `src/core/config.js` | `buildings.chiller.litersPerCoolUnit: 1.8`; `economy.waterCostPerLiter: 0.009`; `events.drought` (interval 110–170 s, duration 25–40 s, `multiplier: 12`). Each with the reasoning inline. |
+| `src/core/state.js` | `STATE.water = { litersPerHour, totalLiters, itKwh }` and `STATE.drought = { active, endsAt, nextAt, multiplier }`, both added to `resetState()` as fresh literals. |
+| `src/entities/Building.js` | `waterLitersPerHour` — the plant's billed evaporation rate, owned by `sim/heat.js`, so the inspector shows the number the meter charges rather than restating a formula. |
+| `src/sim/heat.js` | `updateCoolingLoop()` writes `b.waterLitersPerHour = litersPerCoolUnit × coolUnits × duty` per plant and sums them into `STATE.water.litersPerHour`. Rate read off `b.config`, so a dry-cooled plant declares nothing and drinks nothing. |
+| `src/sim/demand.js` | Bills water on the same meter path and the same billing scale (`rate × qty × dt / 60`), multiplied by the drought and **deliberately not** by the electricity tariff. Accumulates `totalLiters` from exactly what it billed, and `itKwh` from `itDrawKw` — WUE's denominator. |
+| `src/sim/crisis.js` | `tickDrought(elapsed, rng)`, the peak-tariff pattern exactly: `nextAt` sentinels, injected rng, multiplier handed back when the window closes. |
+| `src/campaign/campaign.js` | `startLevelState` pins `drought.nextAt = Infinity`; `applyScriptEvent` gains the `drought` kind; `resolve()` clears the latch so a resolved level cannot leave water at ×12 behind the modal. |
+| `src/campaign/lab.js` | `drought` added to `LAB_EVENTS` / `eventSpec` / `resetLab`, so the new window is rehearsable like every other one. |
+
+### UI
+
+| File | Change |
+|---|---|
+| `index.html` | WUE cell beside PUE: live number, run-total line, drought pill. |
+| `src/ui/hud.js` | Live WUE (`litersPerHour / itDrawKw`), the run total (`Run {L} · {L/kWh}`), the drought pill, and a water row on the chiller inspector. All three are hidden in a room that evaporates nothing. |
+| `src/ui/faq.js` | New **Water** tab, `waterRows()` generated from CONFIG — including the break-even price, computed from the same draws the meter bills. |
+| `src/ui/lab-panel.js` | Drought icon (inline SVG) and label. |
+| `game.js` | Drought banner on both edges, gated on the facility actually drinking. |
+| `src/locales/en.js`, `uk.js` | 22 new keys each, plus `faq_b_chiller` extended. Ukrainian written natively, not calqued. |
+
+### Docs / tests
+
+`README.md` (mechanic + test count), `CONTRIBUTING.md` (baseline count),
+`tests/water.test.mjs` (new, 27), `tests/sim/water-hud.test.mjs` (new, 12),
+`tests/lab.test.mjs` + `tests/sim/lab-panel.test.mjs` (the pinned
+`LAB_EVENTS` list and the button count, updated in the same change).
+
+---
+
+## The numbers, and why
+
+**WUE 1.8 L/kWh** (`chiller.litersPerCoolUnit`). A rack's `heatPerKw` is 1.0,
+so a cooling unit in this simulation *is* a kW of heat — which makes 1.8 L per
+cooling-unit-hour literally the figure the industry quotes for an evaporative
+plant. It is not a game knob: the measured live WUE of a settled 24 kW hall is
+**1.779 L/kWh**, i.e. the room reads back the plant's own number, because in
+steady state the heat rejected equals the IT load. `tests/water.test.mjs` pins
+that correspondence.
+
+**Water at $0.009/L.** Under a cent a litre — the right order for industrial
+water — and low enough that the loop still wins in normal conditions, which is
+true to life and the whole reason evaporative cooling exists. At full output:
+
+```
+plant  45 units for  6.00 kW   +  4.5 CRAHs @ 0.7 =  9.15 kW
+CRACs  45 units for 13.50 kW              (4.5 × 3.0)
+saved  4.35 kW  =  $3.91 per billing hour
+water  45 × 1.8 =  81 L/hr  =  $0.73 per billing hour
+```
+
+Water eats **19%** of the loop's advantage. The loop is still obviously right.
+
+**Break-even $0.048/L** at full output — the price at which the tower costs
+what the efficiency saves. At the part load a real room actually runs at the
+plant's fixed draw is spread over less cooling, and break-even rises to a
+measured **$0.058/L**.
+
+**Drought ×12 → $0.108/L**, roughly double *either* break-even figure. That is
+what it takes: at ×5 the drought price sits under break-even at part load, the
+loop still wins, the decision never flips and the event teaches nothing but a
+slightly larger bill. Real drought surcharges are percentages; this is a
+scarcity price, inflated on the same axis this game's power price already is
+($0.9/kWh against a real ~$0.09). **The physics are not inflated** — 1.8 L per
+kWh rejected, charged on delivered cooling — and those are what the lesson
+rests on.
+
+Measured on a 24 kW hall, same room cooled both ways, 120 s after settling:
+
+| | air-cooled (4 CRAC) | loop (chiller + 4 CRAH) |
+|---|---|---|
+| cooling draw | 9.363 kW | 6.609 kW |
+| PUE | 1.3901 | 1.2754 |
+| water | 0 L/hr | 42.69 L/hr |
+| **earned, standing price** | $84.05 | **$88.22** ← loop wins |
+| **earned, in a drought** | **$84.05** ← CRAC wins | $79.88 |
+
+A clean, symmetric sign flip of about $4.17 each way. The PUE column does not
+move between the drought and the standing price — the flip is the water, not a
+side effect on the power meter, and there is a test for exactly that.
+
+---
+
+## Did any level pair move? No.
+
+All thirteen levels' machine-played pairs still pass unchanged (406/406 of the
+pre-existing tests were green immediately after the sim change, before a single
+new test was written). Water touches **money only** — PUE is untouched by
+construction — and the two Chapter 4 rooms are the only levels with a plant in
+them. Measured before/after, where "before" is the pre-feature meter reproduced
+by pricing water at zero:
+
+| build | verdict before → after | best PUE Δ | money before → after |
+|---|---|---|---|
+| `water_loop` **WIN** (chiller + 4 CRAH) | won @110.05 s → won @110.05 s | **0.000000** | $142.57 → $142.02 (−$0.55) |
+| `water_loop` LOSE (4 CRAC) | failed → failed | 0 | $315.53 → $315.53 (0) |
+| `water_loop` LOSE (heads, no plant) | failed → failed | 0 | $311.46 → $311.46 (0) |
+| `single_point_of_cold` **WIN** (mixed) | won @176.85 s → won @176.85 s | **0.000000** | $175.84 → $175.67 (−$0.17) |
+| `single_point_of_cold` LOSE (as handed over) | failed → failed | 0 | $234.17 → $233.91 (−$0.26) |
+
+`water_loop`'s WIN requires the loop to beat CRACs on PUE, and its end-of-run
+PUE is **1.2688 before and 1.2688 after**, best 1.1042 both — identical,
+because water is billed in dollars and never in watts. Its worst-money moment
+stays $59.97 against a floor of −$150.
+
+The remaining eleven levels have no chiller anywhere in them, and a test pins
+that fact so it cannot quietly stop being true.
+
+---
+
+## Mutation list — real, pasted output
+
+Each mutation was applied to the shipped source, the full suite run, and the
+source restored from backup. Commands and output below are verbatim.
+
+### M1 — water is free (the money line deleted)
+
+```
+### M1-water-is-free
+     × charges one billing hour per GAME MINUTE, like every other rate 6ms
+     × the run ledger is exactly the quantity that was billed 1ms
+     × a DROUGHT multiplies the water line by exactly its multiplier 0ms
+     × TWO UTILITIES, TWO PRICES: the peak tariff never touches water 0ms
+     × IN A DROUGHT the air-cooled room is the cheaper one — the CRAC stops being strictly worse 183ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  5 failed | 440 passed (445)
+```
+
+### M2 — billed on the NAMEPLATE, not the cooling delivered (`× b.duty` → `× 1`)
+
+```
+### M2-nameplate-not-delivered
+     × bills the cooling DELIVERED, never the nameplate: an idle plant costs power and no water 25ms
+     × is exactly litres-per-unit x capacity x duty — proportional, at any part load 106ms
+     × a broken plant's tower stops with it — a dead plant is billed no water 107ms
+     × an UNWIRED plant drinks nothing — a spare in the yard is not a water bill 107ms
+     × a room whose cooling matches its IT load reads the PLANT's own WUE 62ms
+     × the run total is litres over IT kWh, and both are real numbers 77ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  6 failed | 438 passed (444)
+```
+
+### M3 — CRACs drink too (the whole trade deleted)
+
+```
+### M3-cracs-drink-too
+     × THE TRADE: the plant evaporates water; the CRACs doing the same job drink nothing 90ms
+     × IN A DROUGHT the air-cooled room is the cheaper one — the CRAC stops being strictly worse 154ms
+     × an air-cooled hall evaporates nothing and has no WUE to report 56ms
+     × the attribution.test.mjs pattern: a drought on EVERY tick changes not one number 139ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  4 failed | 440 passed (444)
+```
+
+### M4 — the drought multiplier ignored on the water line
+
+```
+### M4-drought-multiplier-ignored
+     × a DROUGHT multiplies the water line by exactly its multiplier 16ms
+     × IN A DROUGHT the air-cooled room is the cheaper one — the CRAC stops being strictly worse 128ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  2 failed | 442 passed (444)
+```
+
+### M5a — WUE's ledger denominator is FACILITY energy, not IT energy
+
+```
+### M5a-wue-denominator-is-facility-energy
+     × THE DENOMINATOR IS IT ENERGY — not facility energy, which is PUE's job 4ms
+     × accumulates the denominator tick for tick over a real run 86ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  2 failed | 442 passed (444)
+```
+
+### M5b — the HUD's live WUE divides by facility draw instead of IT draw
+
+```
+### M5b-hud-wue-wrong-denominator
+     × reads litres per kWh of IT energy — the industry's number, not a PUE-shaped one 10ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  1 failed | 444 passed (445)
+```
+
+### M6 — a dead plant keeps evaporating (water ignores `isRunning`)
+
+```
+### M6-dead-plant-keeps-evaporating
+     × a dead plant's tower stops even when a healthy twin is still running 45ms
+     × an UNWIRED plant drinks nothing — a spare in the yard is not a water bill 79ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  2 failed | 443 passed (445)
+```
+
+### M7 — campaign levels no longer pin the drought schedule
+
+```
+### M7-campaign-does-not-pin-drought
+     × EVERY campaign level pins it to Infinity — no proven level can see one 6ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  1 failed | 444 passed (445)
+```
+
+### M8 — a resolved level leaves the drought window latched open
+
+```
+### M8-resolve-leaves-drought-latched
+     × a level resolving mid-drought closes the window on the way out 5ms
+ Test Files  1 failed | 22 passed (23)
+      Tests  1 failed | 444 passed (445)
+```
+
+### M9 — the standing water price set to zero in CONFIG
+
+```
+### M9-water-price-zero
+     × THE PAGE CANNOT LIE: the drought price it prints really is past break-even 19ms
+     × IN A DROUGHT the air-cooled room is the cheaper one — the CRAC stops being strictly worse 162ms
+ Test Files  2 failed | 21 passed (23)
+      Tests  2 failed | 442 passed (444)
+```
+
+### M10 — the drought multiplier tuned below break-even (×12 → ×3)
+
+```
+### M10-drought-below-break-even
+     × THE PAGE CANNOT LIE: the drought price it prints really is past break-even 3ms
+     × IN A DROUGHT the air-cooled room is the cheaper one — the CRAC stops being strictly worse 211ms
+ Test Files  2 failed | 21 passed (23)
+      Tests  2 failed | 442 passed (444)
+```
+
+### Two mutations the FIRST pass did not catch — and what was wrong
+
+Worth recording, because in both cases the failure was in the tests, not the
+mechanic, and a mutation list that only reports successes is not evidence.
+
+- **M7 initially stayed GREEN.** The test looped every level asserting
+  `drought.nextAt === Infinity` after `startLevelState` — but its own `fresh()`
+  helper pinned every schedule *before* the level start, so the assertion was
+  reading its own setup. A test that certifies the break. Fixed to `resetState`
+  only, plus an assertion that `nextAt` is `null` beforehand, so only the level
+  start can make it `Infinity`. It now goes red (above).
+- **M8 initially stayed GREEN** — but that one was a mis-applied patch (a
+  `\Q…\E` quoted the `\n` literally), not a test gap. Re-applied correctly, it
+  goes red.
+
+A third weakness was found and fixed while doing this: the "broken plant"
+test could not distinguish a mutant that ignored `isRunning`, because killing
+the *only* plant drops loop capacity to zero and every formula then reads zero.
+A second test with a healthy twin carrying the room now covers it — that is the
+second failure in M6.
+
+---
+
+## Campaign level: skipped, and why
+
+**No level was added.** It does not fall out cleanly, and the arithmetic says
+so.
+
+A drought's entire effect is money. The engine's primary objective types are
+`serve_kwh`, `serve_kwh_during_event`, `pue_below`, `no_throttle` and
+`maintenance_without_loss`; `money_at_least` is bonus-only by design and
+CONTRIBUTING explicitly warns against promoting it. So a drought level would
+have to be won or lost on the `failConditions.moneyBelow` floor — the loop
+build bleeding under it while the CRAC build survives.
+
+The separation available is far too small to build a proof on. At the operating
+point the loop saves $2.48 a billing hour on power and pays $4.61 on water in a
+drought — a difference of **$2.13 per billing hour, about $7 over a 200 s
+level**, against roughly $240 of revenue in the same window. That is a 3%
+margin on a level whose verdict would hinge on it: a knife-edge level, which is
+exactly what this project's review rejects, and it would be one CONFIG retune
+away from silently inverting.
+
+The lesson is proven instead where the margin is honest — as a machine-played
+pair in `tests/water.test.mjs` ("AT THE STANDING PRICE the loop is still the
+cheaper room" / "IN A DROUGHT the air-cooled room is the cheaper one"), which
+makes the same claim with the same rigour and without a level that is a coin
+toss. If a drought level is wanted later, the honest route is a bigger room or
+a money-shaped primary objective — an engine change worth its own issue.
+
+---
+
+## Concerns / notes for review
+
+1. **×12 is the number a reviewer should push on.** The physics are anchored
+   (1.8 L/kWh, charged on delivered cooling); the multiplier is a game-economy
+   knob chosen so the decision actually flips. The reasoning and the rejected
+   alternative are in the config comment, and `THE PAGE CANNOT LIE` fails if
+   anyone tunes it back under break-even.
+2. **The drought is survival-only in practice.** Every campaign level pins its
+   schedule to `Infinity` (pinned by a test), so it appears in free play and in
+   The Lab. That is what keeps all thirteen proofs untouched.
+3. **The banner and pill are gated on the facility actually drinking.** An
+   air-cooled hall is never told about a drought it cannot pay for. Defensible
+   as noise-control and required by the inertness brief, but it is a product
+   decision, not a physics one, and it is worth a second opinion.
+4. **Loop membership for water is by literal type**, exactly like the existing
+   supply/demand branches — a second plant type added without a branch would
+   drink nothing and the suite would stay green. Noted in the code, and it is
+   the same trap CONTRIBUTING already documents for `needsLoop`.
+5. **The FAQ table prints English units in the Ukrainian UI** (`81 L/hr`,
+   `$0.009/L`). That matches the existing tariff and shaving tables exactly, so
+   it is consistent rather than an oversight — but if those are ever localised,
+   this table should go with them.
+6. **`whitespace-nowrap` on the two new pills** was added after seeing the HUD
+   in a real browser: without it the run line wraps inside the narrow cell and
+   collides with the paused pill. Restated in `hud.js` too, because assigning
+   `className` drops the markup's classes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i
 npm run check     # eslint . && vitest run — exactly what CI runs
 ```
 
-Baseline today: lint clean, 27 test files, 515 tests, about 3 s. CI uses
+Baseline today: lint clean, 27 test files, 517 tests, about 3 s. CI uses
 Node 22. The skip flag matters because `playwright` is a devDependency whose
 postinstall downloads hundreds of MB of browsers that nothing in `check` uses
 — the demo recorder drives system Chrome.
@@ -104,7 +104,7 @@ Never call `Math.random` in a sim module. Schedules use two sentinel values:
 "can never fire" (how a campaign level guarantees a deterministic script).
 
 **`resetState()` is hand-maintained.** Add a field to the `STATE` literal and
-forget `resetState()` and all 515 tests still pass — the field is silently
+forget `resetState()` and all 517 tests still pass — the field is silently
 deleted on the first reset. Call `resetBuildingIds()` alongside every
 `resetState()`, and `resetWireIds()` too if you use `src/sim/build.js`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i
 npm run check     # eslint . && vitest run — exactly what CI runs
 ```
 
-Baseline today: lint clean, 26 test files, 510 tests, about 3 s. CI uses
+Baseline today: lint clean, 27 test files, 515 tests, about 3 s. CI uses
 Node 22. The skip flag matters because `playwright` is a devDependency whose
 postinstall downloads hundreds of MB of browsers that nothing in `check` uses
 — the demo recorder drives system Chrome.
@@ -93,9 +93,10 @@ behind the result modal on the *ordinary* path, not the rare one.
 
 **Do not change the tick order.** `tickEvents → tickCrisis → tickDemand →
 resolvePower → tickHeat → tickContracts → tickMaintenance → tickCampaign`. It
-encodes causality, and nothing asserts it: the loop is hand-copied into ten
-test helpers, so reordering `game.js` leaves the whole suite green while the
-shipped game behaves differently. That is the worst failure mode a teaching game has.
+encodes causality, and nothing asserts it: the loop is hand-copied into 17
+test files, so reordering `game.js` leaves the whole suite green while the
+shipped game behaves differently. That is the worst failure mode a teaching
+game has.
 
 **Randomness is injected** — `tickCrisis(dt, elapsed, rng = Math.random)`.
 Never call `Math.random` in a sim module. Schedules use two sentinel values:
@@ -103,7 +104,7 @@ Never call `Math.random` in a sim module. Schedules use two sentinel values:
 "can never fire" (how a campaign level guarantees a deterministic script).
 
 **`resetState()` is hand-maintained.** Add a field to the `STATE` literal and
-forget `resetState()` and all 406 tests still pass — the field is silently
+forget `resetState()` and all 515 tests still pass — the field is silently
 deleted on the first reset. Call `resetBuildingIds()` alongside every
 `resetState()`, and `resetWireIds()` too if you use `src/sim/build.js`.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ real playthrough.
 ## Status
 
 Thirteen campaign levels across five chapters plus The Lab, nine buildings,
-510 tests. Simulation: wired power with inverse-time breakers, a diffusing
+515 tests. Simulation: wired power with inverse-time breakers, a diffusing
 heat field with part-load cooling, a shared chilled-water loop metered for
 water on a WUE, UPS buffers, standby generators with fuel, grid sags,
 per-substation outages, time-of-use and peak tariffs, droughts, peak shaving

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ real playthrough.
 ## Status
 
 Thirteen campaign levels across five chapters plus The Lab, nine buildings,
-515 tests. Simulation: wired power with inverse-time breakers, a diffusing
+517 tests. Simulation: wired power with inverse-time breakers, a diffusing
 heat field with part-load cooling, a shared chilled-water loop metered for
 water on a WUE, UPS buffers, standby generators with fuel, grid sags,
 per-substation outages, time-of-use and peak tariffs, droughts, peak shaving

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,10 +25,11 @@ elapsedGameTime += dt          (skipped while the tutorial is active)
 ```
 
 The order encodes causality. Nothing asserts it: the loop is hand-copied into
-nine test helpers (eleven copies, counting the second inline one in
-`tests/campaign.test.mjs` and `tests/prebuilt.test.mjs`), so reordering
-`game.js` leaves the whole suite green while the shipped game behaves
-differently.
+17 test files, 44 copies in all, so reordering `game.js` leaves the whole
+suite green while the shipped game behaves differently. Those two numbers are
+themselves pinned by `tests/docs-counts.test.mjs` — they drifted four times
+before anyone noticed, which is the same argument this file makes for
+generating the FAQ from CONFIG.
 
 Three consequences, none of which are bugs:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,13 +91,8 @@ if (!Number.isFinite(dt) || dt <= 0) return;
 schedules and charges the power bill while the player is paused. A single NaN
 propagates power → heat → money until the whole HUD reads NaN with no clue
 where it started. `tests/power.test.mjs` pins `0`, NaN, negative, `-0` and
-`Infinity` explicitly.
-
-*Known divergence:* `src/sim/heat.js` guards with `if (dt === 0) return;`
-instead. `tickHeat(NaN)` poisons the entire heat field and `tickHeat(-1)` runs
-the physics backwards; only `game.js`'s `Math.min(0.1, …)` clamp protects it
-today. Aligning it is a good first issue — do not copy the pattern into new
-code.
+`Infinity` explicitly; `tests/heat.test.mjs` pins the same set across
+`tickHeat` and each of its five exported stages.
 
 **A decided run.** There are two flags and they are guarded differently.
 

--- a/src/sim/heat.js
+++ b/src/sim/heat.js
@@ -11,7 +11,8 @@
 //
 // Tick order (tickHeat): rack heat injection -> 4-neighbour diffusion ->
 // dissipation toward ambient -> CRAC cooling -> building thermals. Every
-// stage takes dt (seconds, already timeScale-scaled) and is a no-op at dt=0.
+// stage takes dt (seconds, already timeScale-scaled) and is a no-op unless
+// dt is finite and > 0 — the house guard, same as every other sim module.
 //
 // One-tick CRAC lag (INTENDED): this module writes crac.duty from THIS
 // tick's local excess heat; sim/power.js turns that duty into a kW request
@@ -56,7 +57,7 @@ function currentDiffusion() {
 
 // Stage 1 — each powered rack adds actualKw * heatPerKw * dt to its own cell.
 export function injectRackHeat(dt) {
-    if (dt === 0) return;
+    if (!Number.isFinite(dt) || dt <= 0) return;
     const field = STATE.heatField;
     for (const b of STATE.buildings) {
         if (b.type !== "rack" || b.actualKw <= 0) continue;
@@ -69,7 +70,7 @@ export function injectRackHeat(dt) {
 // rate is clamped to 0.25 — the explicit-scheme stability limit for a
 // 4-neighbour kernel — so dt spikes cannot make the field oscillate/explode.
 export function diffuseField(dt) {
-    if (dt === 0) return;
+    if (!Number.isFinite(dt) || dt <= 0) return;
     const rate = Math.min(currentDiffusion() * dt, 0.25);
     const field = STATE.heatField;
     for (let z = 0; z < N; z++) {
@@ -90,7 +91,7 @@ export function diffuseField(dt) {
 // Stage 3 — passive loss toward ambient: field += (ambient - field) * k.
 // k is clamped to 1 so a huge dt lands exactly on ambient, never beyond it.
 export function dissipateField(dt) {
-    if (dt === 0) return;
+    if (!Number.isFinite(dt) || dt <= 0) return;
     const k = Math.min(CONFIG.heat.dissipation * dt, 1);
     const ambient = currentAmbientC();
     const field = STATE.heatField;
@@ -167,7 +168,7 @@ function updateCoolingLoop() {
 }
 
 export function applyCracCooling(dt) {
-    if (dt === 0) return;
+    if (!Number.isFinite(dt) || dt <= 0) return;
     const field = STATE.heatField;
     const ambient = currentAmbientC();
     // Pass 1: every cooling head works out how hard it WANTS to run, from
@@ -236,7 +237,7 @@ export function applyCracCooling(dt) {
 // cell into tempC; racks derive throttleFactor (1 at/below throttleStartC,
 // linear to 0 at shutdownC, 0 above).
 export function updateBuildingThermals(dt) {
-    if (dt === 0) return;
+    if (!Number.isFinite(dt) || dt <= 0) return;
     const field = STATE.heatField;
     for (const b of STATE.buildings) {
         b.tempC = field[heatIndex(b.gx, b.gz)];
@@ -253,9 +254,10 @@ export function updateBuildingThermals(dt) {
 }
 
 // One thermal tick. dt is in seconds, already timeScale-scaled by the
-// caller; dt === 0 (pause) freezes the field and every derived value.
+// caller; a non-finite or non-positive dt (pause is dt === 0) freezes the
+// field and every derived value — the house guard, see docs/ARCHITECTURE.md.
 export function tickHeat(dt) {
-    if (dt === 0) return;
+    if (!Number.isFinite(dt) || dt <= 0) return;
     injectRackHeat(dt);
     diffuseField(dt);
     dissipateField(dt);

--- a/tests/docs-counts.test.mjs
+++ b/tests/docs-counts.test.mjs
@@ -1,0 +1,114 @@
+// The numbers the docs quote about the repo itself.
+//
+// CONTRIBUTING.md's own first lesson is that hand-written docs drift and
+// generated ones cannot. The buildings table, the tariff bands and the
+// shaving figures all obey it — they are rendered from CONFIG at display
+// time. The counts the docs quote about the CODEBASE were the exception,
+// and they drifted four times in a single working session: the test total,
+// the level and chapter counts, and twice the number of places the game
+// loop is hand-copied into.
+//
+// Nothing here checks prose. It checks the handful of numbers a reader
+// would act on — a contributor who reads "hand-copied into ten test files"
+// and greps for ten places will stop looking after ten.
+//
+// When one of these fails, the fix is the DOC, not the number here: this
+// file counts reality, so a failure means reality moved and the sentence
+// beside it is now telling a contributor something false.
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { CONFIG } from "../src/core/config.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (p) => readFileSync(join(ROOT, p), "utf8");
+
+const CONTRIBUTING = read("CONTRIBUTING.md");
+const ARCHITECTURE = read("docs/ARCHITECTURE.md");
+const README = read("README.md");
+
+// Every file that hand-copies game.js's tick order into a local helper. The
+// marker is a resolvePower call inside a test: nothing else in the suite
+// drives the pipeline by hand.
+function tickLoopFiles() {
+    const files = [];
+    for (const dir of ["tests", "tests/sim"]) {
+        for (const name of readdirSync(join(ROOT, dir))) {
+            if (!name.endsWith(".test.mjs")) continue;
+            const body = read(join(dir, name));
+            if (/resolvePower\s*\(/.test(body)) files.push(join(dir, name));
+        }
+    }
+    return files;
+}
+
+function tickLoopCopies() {
+    let n = 0;
+    for (const f of tickLoopFiles()) {
+        n += (read(f).match(/resolvePower\(DT/g) || []).length;
+    }
+    return n;
+}
+
+// Every number the doc quotes as "N test files" / "N copies" / "N tests".
+const nums = (text, re) => [...text.matchAll(re)].map((m) => Number(m[1]));
+
+describe("the docs' own numbers are still true", () => {
+    it("the tick loop is copied into as many test files as CONTRIBUTING claims", () => {
+        const real = tickLoopFiles().length;
+        const claimed = nums(CONTRIBUTING, /hand-copied into (\d+)\s*\n?test files/g);
+        expect(claimed.length).toBeGreaterThan(0);   // the sentence still exists
+        for (const c of claimed) expect(c).toBe(real);
+    });
+
+    it("ARCHITECTURE quotes the same two numbers, and both are real", () => {
+        const files = tickLoopFiles().length;
+        const copies = tickLoopCopies();
+        const m = ARCHITECTURE.match(/hand-copied into\s*\n?(\d+) test files, (\d+) copies/);
+        expect(m, "the tick-order paragraph moved or lost its numbers").not.toBeNull();
+        expect(Number(m[1])).toBe(files);
+        expect(Number(m[2])).toBe(copies);
+    });
+
+    // The README's claim is about levels that are PROVEN — "each proven, by
+    // machine-played tests, to be winnable with that mechanic and losable
+    // without it". The Lab is a sandbox in its own chapter: it cannot be won,
+    // so it is not one of them and counting it would make the sentence false
+    // a different way. Level select shows the extra chapter, so the README
+    // names it rather than leaving a reader to wonder why six looks like five.
+    it("the level and chapter counts in the README are the campaign's own", () => {
+        const isSandbox = (id) => Boolean(CONFIG.campaign.levels[id].sandbox);
+        const proven = CONFIG.campaign.chapters
+            .map((c) => c.levels.filter((id) => !isSandbox(id)))
+            .filter((ls) => ls.length > 0);
+        const chapters = proven.length;
+        const levels = proven.reduce((n, ls) => n + ls.length, 0);
+        const words = { 12: "Twelve", 13: "Thirteen", 14: "Fourteen", 15: "Fifteen" };
+        const chapterWords = { 4: "four", 5: "five", 6: "six", 7: "seven" };
+        expect(words[levels], `no word for ${levels} levels — extend the map`).toBeTruthy();
+        expect(README).toContain(`${words[levels]} levels in ${chapterWords[chapters]} chapters`);
+        expect(README).toContain(`${words[levels]} campaign levels across ${chapterWords[chapters]} chapters`);
+    });
+
+    it("the building count in the README is CONFIG's own", () => {
+        const n = Object.keys(CONFIG.buildings).length;
+        const words = { 8: "eight", 9: "nine", 10: "ten", 11: "eleven" };
+        expect(words[n], `no word for ${n} buildings — extend the map`).toBeTruthy();
+        expect(README).toContain(`${words[n]} buildings`);
+    });
+
+    // The test total is the one number that changes on almost every commit,
+    // so it is quoted in three places and was stale in one of them twice.
+    // Counting it from inside the suite is circular; what is checkable is
+    // that every place quoting it quotes the SAME number.
+    it("every doc that quotes a test total quotes the same one", () => {
+        const quoted = [
+            ...nums(CONTRIBUTING, /(\d+) tests, about/g),
+            ...nums(CONTRIBUTING, /and all (\d+) tests still pass/g),
+            ...nums(README, /(\d+) tests\./g),
+        ];
+        expect(quoted.length).toBeGreaterThanOrEqual(3);
+        expect(new Set(quoted).size, `the docs disagree: ${[...new Set(quoted)].join(" vs ")}`).toBe(1);
+    });
+});

--- a/tests/heat.test.mjs
+++ b/tests/heat.test.mjs
@@ -284,6 +284,23 @@ describe("invariants", () => {
         expect(crac.duty).toBe(0.77);
     });
 
+    it("tickHeat(NaN), tickHeat(-1), tickHeat(-0) and tickHeat(Infinity) are all full no-ops", () => {
+        const rack = addRack(8, 8, 6);
+        const crac = addCrac(12, 8, true);
+        setCell(8, 8, 55);
+        rack.tempC = 51;
+        rack.throttleFactor = 0.3;
+        crac.duty = 0.77;
+        const snapshot = Array.from(STATE.heatField);
+        for (const bad of [NaN, -1, -0, Infinity]) {
+            tickHeat(bad);
+            expect(Array.from(STATE.heatField)).toEqual(snapshot);
+            expect(rack.tempC).toBe(51);
+            expect(rack.throttleFactor).toBe(0.3);
+            expect(crac.duty).toBe(0.77);
+        }
+    });
+
     it("conservation: field delta per stage matches added - dissipated - removed", () => {
         const rack = addRack(8, 8, 6);
         const crac = addCrac(12, 8, true);
@@ -373,6 +390,33 @@ describe("adversarial", () => {
         applyCracCooling(0); // must NOT rewrite duty either
         updateBuildingThermals(0); // must NOT rewrite tempC/throttleFactor
         expect(Array.from(STATE.heatField)).toEqual(snapshot);
+        expect(crac.duty).toBe(0.77);
+        expect(rack.tempC).toBe(51);
+        expect(rack.throttleFactor).toBe(0.3);
+    });
+
+    it("per-stage guards hold against NaN, negative, -0 and Infinity on dirty state", () => {
+        const rack = addRack(8, 8, 6);
+        const crac = addCrac(12, 8, true);
+        setCell(8, 8, 55);
+        setCell(12, 8, 60);
+        rack.tempC = 51;
+        rack.throttleFactor = 0.3;
+        crac.duty = 0.77;
+        const snapshot = Array.from(STATE.heatField);
+        const buildingSnapshot = () => STATE.buildings.map((b) => ({
+            tempC: b.tempC, duty: b.duty, throttleFactor: b.throttleFactor,
+        }));
+        const before = buildingSnapshot();
+        for (const bad of [NaN, -1, -0, Infinity]) {
+            injectRackHeat(bad);
+            diffuseField(bad);
+            dissipateField(bad);
+            applyCracCooling(bad); // must NOT rewrite duty either
+            updateBuildingThermals(bad); // must NOT rewrite tempC/throttleFactor
+            expect(Array.from(STATE.heatField)).toEqual(snapshot);
+            expect(buildingSnapshot()).toEqual(before);
+        }
         expect(crac.duty).toBe(0.77);
         expect(rack.tempC).toBe(51);
         expect(rack.throttleFactor).toBe(0.3);


### PR DESCRIPTION
Closes [#12](https://github.com/pshenok/datacenter-survival/issues/12). 515 → **517 tests**, no existing test touched.

Every sim module opens its exported ticks with `if (!Number.isFinite(dt) || dt <= 0) return;`. `src/sim/heat.js` used `if (dt === 0) return;` throughout, and `docs/ARCHITECTURE.md` has been calling that out by name under "Known divergence" ever since: `tickHeat(NaN)` poisons the entire heat field and `tickHeat(-1)` runs the physics backwards.

The clamp that was supposedly protecting it does not. `Math.min(0.1, NaN)` is NaN and `Math.min(0.1, -1)` is -1 — and the clamp lives in `game.js`, which none of the seventeen hand-copied test loops go through. The only real protection was that nothing happens to pass a bad value today.

A single NaN there does not stay there: field → `tempC` → `throttleFactor` → served kW → money, and the HUD ends up reading NaN with nothing pointing at where it started. That is the failure the guard exists to prevent everywhere else in the sim.

All six exported stages now carry the house guard, and `tests/heat.test.mjs` pins NaN, `-1`, `-0` and `Infinity` as strict no-ops — the field and every building's `tempC`, `duty` and `throttleFactor` untouched — in the shape `tests/power.test.mjs` already uses for its own.

The "Known divergence" paragraph is gone from ARCHITECTURE, since it now describes a state that no longer exists.

## Note on the mutation list

Five of the six stages go red when their guard is reverted. **`tickHeat`'s own guard does not**, and that is a real structural property rather than a gap in the tests: because all five stages it calls are individually guarded, a bad `dt` is absorbed before anything observable happens, so no black-box assertion can tell a broken top-level guard from a working one. It is kept anyway — it matches the house pattern, and it is what protects a future sixth stage that forgets its own.

This is a widening: it can only turn calls that previously did something into no-ops, and nothing passes a bad `dt` today. All 515 pre-existing tests pass unchanged, and the thirteen campaign pairs re-verified unmoved.