### PR TITLE
The repo is MIT now, so stop saying it is not

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,12 +330,10 @@ is a real, verified gap with the fix already located.
 
 ## Licensing
 
-**There is no license declared for this repository yet.** There is no
-`LICENSE` file and `package.json` has no `license` field, so the default is
-all rights reserved and the terms under which contributions are accepted are
-currently undefined. This is an oversight, not a position — the project is
-public, deployed, and asking for contributions. If you are planning anything
-substantial, ask in
-[Discussions](https://github.com/pshenok/datacenter-survival/discussions) and
-the maintainer will settle it. Do not assume MIT because the sister project
-uses it.
+**MIT**, the same as [Server Survival](https://github.com/pshenok/server-survival)
+— see [LICENSE](LICENSE). By opening a pull request you are offering your
+contribution under those terms.
+
+`package.json` keeps `"private": true`, which is about npm and not about
+rights: it stops the dev-tooling manifest being published as a package by
+accident. The game itself is MIT and always served straight from the repo.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Dev tooling for Datacenter Survival. The game has NO build step — served raw by GitHub Pages. Tooling is optional, for contributors.",
+  "license": "MIT",
   "scripts": {
     "lint": "eslint .",
     "test": "vitest run",


### PR DESCRIPTION
`LICENSE` landed, which made two things in the repo false.

**`CONTRIBUTING.md`** opened its Licensing section with *"There is no license declared for this repository yet"* and told readers not to assume MIT because the sister project uses it. That was accurate when written and wrong the moment the file was committed — and it sits at the bottom of the one document a would-be contributor reads before deciding whether they can legally send a patch at all.

**`package.json`** had no `license` field. It now says MIT.

It keeps `"private": true`, which is about npm and not about rights: it stops the dev-tooling manifest being published as a package by accident. The two sitting side by side read as a contradiction, so the new text says which is which.

GitHub already shows the MIT badge and the repo now answers license filters — small, but not nothing for an OSS project that wants to be found.