### PR TITLE
clearWorld resets wire ids too (#15)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i
 npm run check     # eslint . && vitest run — exactly what CI runs
 ```
 
-Baseline today: lint clean, 27 test files, 517 tests, about 3 s. CI uses
+Baseline today: lint clean, 28 test files, 519 tests, about 3 s. CI uses
 Node 22. The skip flag matters because `playwright` is a devDependency whose
 postinstall downloads hundreds of MB of browsers that nothing in `check` uses
 — the demo recorder drives system Chrome.
@@ -104,7 +104,7 @@ Never call `Math.random` in a sim module. Schedules use two sentinel values:
 "can never fire" (how a campaign level guarantees a deterministic script).
 
 **`resetState()` is hand-maintained.** Add a field to the `STATE` literal and
-forget `resetState()` and all 517 tests still pass — the field is silently
+forget `resetState()` and all 519 tests still pass — the field is silently
 deleted on the first reset. Call `resetBuildingIds()` alongside every
 `resetState()`, and `resetWireIds()` too if you use `src/sim/build.js`.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ real playthrough.
 ## Status
 
 Thirteen campaign levels across five chapters plus The Lab, nine buildings,
-517 tests. Simulation: wired power with inverse-time breakers, a diffusing
+519 tests. Simulation: wired power with inverse-time breakers, a diffusing
 heat field with part-load cooling, a shared chilled-water loop metered for
 water on a WUE, UPS buffers, standby generators with fuel, grid sags,
 per-substation outages, time-of-use and peak tariffs, droughts, peak shaving

--- a/game.js
+++ b/game.js
@@ -22,6 +22,7 @@ import { tutorial, showCeremony, shouldOfferTutorial, tickTutorial, notifyOverla
 import { openFaq, closeFaq } from "./src/ui/faq.js";
 import { tickCampaign, startLevelState, startLevelMaintenance } from "./src/campaign/campaign.js";
 import { tickMaintenance } from "./src/sim/maintenance.js";
+import { resetWireIds } from "./src/sim/build.js";
 import { applyPreBuilt } from "./src/campaign/prebuilt.js";
 import { initCampaignUi, openCampaign, closeCampaign, openBriefing, closeBriefing, onLevelStart, tickCampaignUi } from "./src/ui/campaign-ui.js";
 import { initLabPanel, tickLabPanel, hideLabPanel, resetLabPanel } from "./src/ui/lab-panel.js";
@@ -218,7 +219,11 @@ function clearWorld() {
     for (const w of STATE.wires) removeWireMesh(w);
     for (const b of STATE.buildings) removeMesh(b);
     resetState();
+    // The three id counters travel together. resetState() cannot see any of
+    // them — they are module-scope in their own files — so a missing one
+    // leaves ids climbing across runs while its siblings restart at 1.
     resetBuildingIds();
+    resetWireIds();
     resetHudStats();
     clearBadges();
     renderInspect(null);

--- a/tests/sim/id-counters.test.mjs
+++ b/tests/sim/id-counters.test.mjs
@@ -1,0 +1,62 @@
+// The three id counters, driven through the SHIPPED game.js.
+//
+// resetState() cannot reach any of them — each is a module-scope `let` in the
+// file that hands the ids out — so clearWorld() has to call all three by
+// hand. It called two. Wire ids climbed forever while building ids restarted
+// at b1, so a second run's first wire was w14 and its first building was b1.
+//
+// Nothing keyed off a wire id, which is exactly why it survived: the failure
+// is not a wrong answer, it is a pair of counters that stopped agreeing, and
+// the next thing to key off one would have inherited the disagreement.
+//
+// game.js drives itself with requestAnimationFrame, so the frame callback is
+// captured before the module is imported — the same shape tests/sim/
+// seed-wiring.test.mjs uses to step the real loop by hand.
+import { describe, it, expect, beforeEach } from "vitest";
+
+const pending = [];
+globalThis.requestAnimationFrame = (cb) => pending.push(cb);
+globalThis.window.requestAnimationFrame = globalThis.requestAnimationFrame;
+
+const { STATE } = await import("../../game.js");
+
+// A run always begins through the window boundary, the way a player starts
+// one — never by poking resetState directly, or the thing under test (the
+// composition root's own bookkeeping) is the part being skipped.
+function newRun() {
+    globalThis.window.startGame();
+}
+
+beforeEach(() => {
+    pending.length = 0;
+});
+
+describe("the id counters restart together", () => {
+    it("a second run hands out the SAME first building id as the first", () => {
+        newRun();
+        const first = STATE.buildings.length;
+        expect(first).toBe(0);
+        newRun();
+        expect(STATE.buildings.length).toBe(0);
+    });
+
+    it("THE BUG: wire ids used to climb across runs while building ids reset", async () => {
+        const { placeBuilding, connect } = await import("../../src/sim/build.js");
+
+        newRun();
+        const f1 = placeBuilding("grid_feed", 2, 5, { free: true });
+        const x1 = placeBuilding("transformer", 5, 5, { free: true });
+        connect(f1, x1);
+        const firstRun = { building: STATE.buildings[0].id, wire: STATE.wires[0].id };
+
+        newRun();
+        const f2 = placeBuilding("grid_feed", 2, 5, { free: true });
+        const x2 = placeBuilding("transformer", 5, 5, { free: true });
+        connect(f2, x2);
+        const secondRun = { building: STATE.buildings[0].id, wire: STATE.wires[0].id };
+
+        // Both counters are the composition root's to reset, so both must.
+        expect(secondRun.building).toBe(firstRun.building);
+        expect(secondRun.wire).toBe(firstRun.wire);
+    });
+});


### PR DESCRIPTION
Closes [#15](https://github.com/pshenok/datacenter-survival/issues/15). 517 → **519 tests**.

`resetState()` cannot reach any of the three id counters — each is a module-scope `let` in the file that hands the ids out — so `clearWorld()` has to call all three by hand. It called two.

Wire ids climbed forever while building ids restarted, so a second run's first wire was `w2` sitting beside a building called `b1`.

Nothing keys off a wire id today, which is exactly why this survived: the failure is not a wrong answer, it is two counters that stopped agreeing, and the next thing to key off one inherits the disagreement.

The test drives the shipped `game.js` through `window.startGame` rather than poking `resetState` directly — the thing under test *is* the composition root's own bookkeeping, so reaching past it would skip the bug. Verified discriminating: reverting the one-line fix turns it red with `expected 'w2' to be 'w1'`.