### PR TITLE
playwright-core, so npm i stops downloading browsers (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,6 @@ jobs:
       # from CDNs, there is no build step), so the lockfile only pins a
       # linter and a test runner. Reproducibility of the shipped artifact does
       # not pass through here at all.
-      #
-      # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: nothing in `check` drives a browser
-      # — the demo recorder uses system Chrome — and the download is hundreds
-      # of MB per run.
       - run: npm install --no-audit --no-fund
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - run: npm run lint
       - run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,13 @@ before you check your server.
 Tooling is optional and only for contributors:
 
 ```bash
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i
+npm i
 npm run check     # eslint . && vitest run — exactly what CI runs
 ```
 
 Baseline today: lint clean, 28 test files, 519 tests, about 3 s. CI uses
-Node 22. The skip flag matters because `playwright` is a devDependency whose
-postinstall downloads hundreds of MB of browsers that nothing in `check` uses
-— the demo recorder drives system Chrome.
+Node 22. Nothing here downloads a browser: the demo recorder drives your
+system Chrome through `playwright-core`, which ships no binaries.
 
 ## The invariants, and what breaks when you cross one
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,13 @@
     "": {
       "name": "datacenter-survival",
       "version": "0.1.0",
+      "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "eslint": "^10.7.0",
         "globals": "^17.7.0",
         "happy-dom": "^20.11.1",
-        "playwright": "^1.62.1",
+        "playwright-core": "^1.62.1",
         "vitest": "^4.1.10"
       }
     },
@@ -1775,25 +1776,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.62.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
     "node_modules/playwright-core": {
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
@@ -1805,21 +1787,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint": "^10.7.0",
     "globals": "^17.7.0",
     "happy-dom": "^20.11.1",
-    "playwright": "^1.62.1",
+    "playwright-core": "^1.62.1",
     "vitest": "^4.1.10"
   }
 }

--- a/tools/capture-demo.mjs
+++ b/tools/capture-demo.mjs
@@ -9,7 +9,7 @@
 //   node tools/capture-demo.mjs [port] [outDir]
 //
 // Frames land as PNGs; assemble with ffmpeg (see tools/make-gif.sh).
-import { chromium } from "playwright";
+import { chromium } from "playwright-core";
 import { mkdirSync, rmSync } from "node:fs";
 
 const PORT = process.argv[2] || "8299";


### PR DESCRIPTION
Closes [#16](https://github.com/pshenok/datacenter-survival/issues/16).

`playwright` was a devDependency whose postinstall pulls hundreds of MB of browser binaries before a test suite that runs in three seconds and never touches them. `tools/capture-demo.mjs` said as much in its own comment — *"uses the system Chrome (channel) so no 150 MB browser download is needed"* — which was true at run time and false at install time.

`playwright-core` ships no binaries and has no `scripts` block at all, and it supports `channel: "chrome"`, which is the only launch mode the recorder ever uses.

**Verified by running the real thing**, not by reasoning about it: the recorder was pointed at a live server on the swapped dependency and produced 284 frames from an actual playthrough, ledger output and all.

This also retires `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` from CONTRIBUTING's install line and from the CI workflow, where it existed as a workaround for exactly this dependency.