### PR TITLE
no-unused-vars back on (#14)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,8 +6,12 @@ import globals from "globals";
 // Every first-party file is now a real ES module with explicit imports, so
 // no-undef is ON: any bare identifier that isn't imported or a known browser
 // global is an error. THREE stays a classic CDN global (r128), so it is
-// declared here instead of imported. no-unused-vars stays off until the
-// split PRs land (game.js still exports a wide surface).
+// declared here instead of imported.
+//
+// no-unused-vars is ON. It was parked "until the split PRs land"; they have,
+// and turning it on surfaced exactly three dead imports across 29 test files
+// and 30 modules — cheap to keep honest, and the rule that catches a
+// half-finished refactor before review does.
 export default [
   {
     ignores: ["node_modules/**", "assets/**", "market/**"],
@@ -23,7 +27,7 @@ export default [
       },
     },
     rules: {
-      "no-unused-vars": "off",
+      "no-unused-vars": "error",
       "no-empty": ["error", { allowEmptyCatch: true }],
     },
   },

--- a/src/input/handlers.js
+++ b/src/input/handlers.js
@@ -7,7 +7,7 @@ import { STATE } from "../core/state.js";
 import { placeBuilding as simPlace, connect as simConnect, demolishBuilding as simDemolish } from "../sim/build.js";
 import { repairCrac, orderFuel, resetBreaker } from "../sim/crisis.js";
 import { pendingOrderFor, openServiceWindow } from "../sim/maintenance.js";
-import { camera, cameraTarget, renderer, worldToGrid, gridToWorld, buildingGroup, focusWorld } from "../ui/scene.js";
+import { camera, cameraTarget, renderer, worldToGrid, buildingGroup, focusWorld } from "../ui/scene.js";
 import { attachMesh, addWireMesh, removeWireMesh, removeMesh } from "../ui/meshes.js";
 import { markActiveTool, refreshAffordability } from "../ui/toolbar.js";
 import { renderInspect, showBanner } from "../ui/hud.js";

--- a/tests/maintenance.test.mjs
+++ b/tests/maintenance.test.mjs
@@ -16,7 +16,7 @@ import {
     initMaintenance, tickMaintenance, openServiceWindow,
     pendingOrderFor, activeOrderCount,
 } from "../src/sim/maintenance.js";
-import { tickCampaign, startLevelState, levelCfg } from "../src/campaign/campaign.js";
+import { tickCampaign } from "../src/campaign/campaign.js";
 import { demolishBuilding } from "../src/sim/build.js";
 
 const DT = 0.05;


### PR DESCRIPTION
Closes [#14](https://github.com/pshenok/datacenter-survival/issues/14).

The rule was parked *"until the split PRs land"*. They landed a long time ago — `src/` is 30 modules and `game.js` is a composition root — and the comment outlived the condition it named.

Turning it on surfaced **exactly three dead imports** across 30 modules and 29 test files: `gridToWorld` in the input layer, `startLevelState` and `levelCfg` in the maintenance suite. That is the entire cost. The benefit is that the next half-finished refactor gets caught by lint instead of by a reviewer.

Verified the rule actually bites: a deliberately unused `const` was flagged, then removed again.

The comment beside it still cites `#155` and still ignores `market/**`, both inherited from Server Survival. Left alone deliberately — that is [#8](https://github.com/pshenok/datacenter-survival/issues/8), tagged `good first issue` and reserved for whoever arrives.