### PR TITLE
Walking out of the tutorial no longer freezes every later run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ npm i
 npm run check     # eslint . && vitest run — exactly what CI runs
 ```
 
-Baseline today: lint clean, 29 test files, 531 tests, about 3 s. CI uses
+Baseline today: lint clean, 30 test files, 535 tests, about 3 s. CI uses
 Node 22. Nothing here downloads a browser: the demo recorder drives your
 system Chrome through `playwright-core`, which ships no binaries.
 
@@ -103,7 +103,7 @@ Never call `Math.random` in a sim module. Schedules use two sentinel values:
 "can never fire" (how a campaign level guarantees a deterministic script).
 
 **`resetState()` is hand-maintained.** Add a field to the `STATE` literal and
-forget `resetState()` and all 531 tests still pass — the field is silently
+forget `resetState()` and all 535 tests still pass — the field is silently
 deleted on the first reset. Call `resetBuildingIds()` alongside every
 `resetState()`, and `resetWireIds()` too if you use `src/sim/build.js`.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ real playthrough.
 ## Status
 
 Thirteen campaign levels across five chapters plus The Lab, nine buildings,
-531 tests. Simulation: wired power with inverse-time breakers, a diffusing
+535 tests. Simulation: wired power with inverse-time breakers, a diffusing
 heat field with part-load cooling, a shared chilled-water loop metered for
 water on a WUE, UPS buffers, standby generators with fuel, grid sags,
 per-substation outages, time-of-use and peak tariffs, droughts, peak shaving

--- a/game.js
+++ b/game.js
@@ -18,7 +18,7 @@ import { tickPulses } from "./src/ui/pulses.js";
 import { tickBadges, clearBadges } from "./src/ui/failure-badges.js";
 import { renderPalette, refreshAffordability } from "./src/ui/toolbar.js";
 import { setTool, tickInspect, tickCameraPan } from "./src/input/handlers.js";
-import { tutorial, showCeremony, shouldOfferTutorial, tickTutorial, notifyOverlayToggled } from "./src/ui/tutorial.js";
+import { tutorial, showCeremony, shouldOfferTutorial, tickTutorial, notifyOverlayToggled, abandonTutorial } from "./src/ui/tutorial.js";
 import { openFaq, closeFaq } from "./src/ui/faq.js";
 import { tickCampaign, startLevelState, startLevelMaintenance } from "./src/campaign/campaign.js";
 import { tickMaintenance } from "./src/sim/maintenance.js";
@@ -217,6 +217,9 @@ function animate(time) {
 }
 
 function clearWorld() {
+    // A tutorial the player walked out of stays `active` otherwise, and the
+    // game clock is gated on that flag — see abandonTutorial().
+    abandonTutorial();
     for (const w of STATE.wires) removeWireMesh(w);
     for (const b of STATE.buildings) removeMesh(b);
     resetState();
@@ -421,6 +424,7 @@ window.briefingBack = () => {
 };
 window.backToMenu = () => {
     STATE.isRunning = false;
+    abandonTutorial();
     for (const id of ["gameover-modal", "objectives-panel", "lab-panel", "pause-menu-modal", "briefing-modal", "level-result-modal"]) {
         document.getElementById(id).classList.add("hidden");
     }

--- a/src/ui/tutorial.js
+++ b/src/ui/tutorial.js
@@ -145,6 +145,26 @@ export function skipTutorial() {
     finish(false);
 }
 
+// Abandoning a run mid-lesson — Esc, the pause menu, back to the main menu.
+//
+// This is NOT skipTutorial(). Skip is a decision ("I know this"), so it marks
+// the tutorial done and never offers again; walking out to the menu is not,
+// so the offer survives. What the two share, and the only part that is not
+// cosmetic, is clearing `active`: game.js gates the whole game clock on it
+// (`if (!tutorial.active) STATE.elapsedGameTime += dt`), and nothing else
+// ever clears it. Left latched, every run started afterwards has a frozen
+// clock — no demand waves, no heatwave, no crisis, no contract, no campaign
+// timer and no maintenance deadline — until the page is reloaded.
+export function abandonTutorial() {
+    if (!tutorial.active) return false;
+    tutorial.active = false;
+    for (const id of ["tut-spotlight", "tut-callout", "tut-checklist"]) {
+        const el = document.getElementById(id);
+        if (el) el.classList.add("hidden");
+    }
+    return true;
+}
+
 function finish(celebrated) {
     tutorial.active = false;
     try {

--- a/tests/sim/tutorial-clock.test.mjs
+++ b/tests/sim/tutorial-clock.test.mjs
@@ -1,0 +1,105 @@
+// The game clock is gated on a module-scope flag nobody was clearing.
+//
+// game.js: `if (!tutorial.active) STATE.elapsedGameTime += dt;` — the
+// tutorial freezes time on purpose, so a first-timer can wire a chain without
+// a heatwave landing on them. The flag was cleared only by finish(): all
+// seven steps done, or the Skip button.
+//
+// Esc opens the pause menu mid-lesson, and the pause menu goes back to the
+// main menu. That path never reached finish(), so `active` stayed true for
+// the life of the page — and EVERY run started afterwards had a frozen clock.
+// Nothing crashes; the game simply stops having weather, crises, contracts,
+// level timers or maintenance deadlines, silently, until a reload.
+//
+// Driven through the SHIPPED game.js, because the defect lives in the
+// composition root's bookkeeping and reaching past it would skip the bug.
+import { describe, it, expect, beforeEach } from "vitest";
+
+const pending = [];
+globalThis.requestAnimationFrame = (cb) => pending.push(cb);
+globalThis.window.requestAnimationFrame = globalThis.requestAnimationFrame;
+
+const { STATE } = await import("../../game.js");
+const { tutorial } = await import("../../src/ui/tutorial.js");
+
+let clock = 0;
+// One frame of the real animate(): 50 ms, under game.js's 0.1 s clamp.
+function frames(n) {
+    for (let i = 0; i < n; i++) {
+        const cb = pending.pop();
+        pending.length = 0;
+        clock += 50;
+        cb(clock);
+    }
+}
+
+// What the ceremony's "teach me" button does: the lesson starts and the
+// clock is deliberately held.
+function enterTutorial() {
+    tutorial.active = true;
+    tutorial.step = 0;
+}
+
+beforeEach(() => {
+    try {
+        localStorage.clear();
+        localStorage.setItem("dc_tutorial_done", "1");   // no ceremony unless a test wants one
+    } catch { /* storage unavailable */ }
+    document.getElementById("ceremony-modal")?.classList.add("hidden");
+    tutorial.active = false;
+});
+
+describe("the tutorial holds the clock, and gives it back", () => {
+    it("freezes game time while the lesson is running — the point of the flag", () => {
+        globalThis.window.startGame();
+        enterTutorial();
+        globalThis.window.togglePause();
+        const before = STATE.elapsedGameTime;
+        frames(20);
+        expect(STATE.elapsedGameTime).toBe(before);
+    });
+
+    it("THE BUG: walking out to the menu mid-lesson used to freeze every later run", () => {
+        globalThis.window.startGame();
+        enterTutorial();
+        expect(tutorial.active).toBe(true);
+
+        // Esc, then the pause menu's way out. Neither is the Skip button.
+        globalThis.window.backToMenu();
+        expect(tutorial.active).toBe(false);
+
+        // A completely new run must have a clock again.
+        globalThis.window.startGame();
+        globalThis.window.togglePause();
+        const before = STATE.elapsedGameTime;
+        frames(20);
+        expect(STATE.elapsedGameTime).toBeGreaterThan(before);
+    });
+
+    it("starting another run also releases it, whichever way the player left", () => {
+        globalThis.window.startGame();
+        enterTutorial();
+        globalThis.window.startGame();          // clearWorld() runs on the way in
+        expect(tutorial.active).toBe(false);
+        globalThis.window.togglePause();
+        const before = STATE.elapsedGameTime;
+        frames(20);
+        expect(STATE.elapsedGameTime).toBeGreaterThan(before);
+    });
+
+    it("abandoning does NOT count as done — the offer survives, unlike Skip", async () => {
+        const { abandonTutorial } = await import("../../src/ui/tutorial.js");
+        try {
+            localStorage.removeItem("dc_tutorial_done");
+        } catch { /* storage unavailable — the assertion below still holds */ }
+        enterTutorial();
+        expect(abandonTutorial()).toBe(true);
+        let done = null;
+        try {
+            done = localStorage.getItem("dc_tutorial_done");
+        } catch { /* ignore */ }
+        expect(done).toBeNull();
+        // Idempotent: leaving twice is not an error.
+        expect(abandonTutorial()).toBe(false);
+    });
+});


### PR DESCRIPTION
Found by an adversarial audit of the whole codebase. 531 → **535 tests**.

`game.js` gates the entire game clock on a module-scope flag:

```js
if (!tutorial.active) STATE.elapsedGameTime += dt;
```

The freeze is deliberate and good — a first-timer wires a chain without a heatwave landing on them mid-lesson. The flag was cleared only by `finish()`: all seven steps completed, or the Skip button.

**Esc opens the pause menu mid-lesson, and the pause menu goes back to the main menu.** Neither path reached `finish()`. So `tutorial.active` stayed `true` for the life of the page, and every run started afterwards had a frozen clock: no demand waves, no heatwave, no brownout, no outage, no contracts, no campaign timers, no maintenance deadlines.

Nothing crashes. Nothing errors. The game quietly stops having weather, and stays that way until the player reloads — which is the worst shape a bug can take in something whose whole job is teaching you what a datacenter does under stress.

`abandonTutorial()` is deliberately **not** `skipTutorial()`. Skip is a decision — *"I know this"* — so it marks the tutorial done and never offers again. Walking out to the menu is not a decision, so the offer survives. The only thing the two must share is releasing the clock.

Wired at both exits, and both are mutation-checked: dropping either the `clearWorld()` call or the `backToMenu()` one turns its own test red.