### PR TITLE
Three conservation defects: fuel, battery energy, and the meter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ npm i
 npm run check     # eslint . && vitest run — exactly what CI runs
 ```
 
-Baseline today: lint clean, 33 test files, 560 tests, about 3 s. CI uses
+Baseline today: lint clean, 33 test files, 567 tests, about 3 s. CI uses
 Node 22. Nothing here downloads a browser: the demo recorder drives your
 system Chrome through `playwright-core`, which ships no binaries.
 
@@ -103,7 +103,7 @@ Never call `Math.random` in a sim module. Schedules use two sentinel values:
 "can never fire" (how a campaign level guarantees a deterministic script).
 
 **`resetState()` is hand-maintained.** Add a field to the `STATE` literal and
-forget `resetState()` and all 560 tests still pass — the field is silently
+forget `resetState()` and all 567 tests still pass — the field is silently
 deleted on the first reset. Call `resetBuildingIds()` alongside every
 `resetState()`, and `resetWireIds()` too if you use `src/sim/build.js`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ npm i
 npm run check     # eslint . && vitest run — exactly what CI runs
 ```
 
-Baseline today: lint clean, 33 test files, 567 tests, about 3 s. CI uses
+Baseline today: lint clean, 33 test files, 570 tests, about 3 s. CI uses
 Node 22. Nothing here downloads a browser: the demo recorder drives your
 system Chrome through `playwright-core`, which ships no binaries.
 
@@ -103,7 +103,7 @@ Never call `Math.random` in a sim module. Schedules use two sentinel values:
 "can never fire" (how a campaign level guarantees a deterministic script).
 
 **`resetState()` is hand-maintained.** Add a field to the `STATE` literal and
-forget `resetState()` and all 567 tests still pass — the field is silently
+forget `resetState()` and all 570 tests still pass — the field is silently
 deleted on the first reset. Call `resetBuildingIds()` alongside every
 `resetState()`, and `resetWireIds()` too if you use `src/sim/build.js`.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ real playthrough.
 ## Status
 
 Thirteen campaign levels across five chapters plus The Lab, nine buildings,
-567 tests. Simulation: wired power with inverse-time breakers, a diffusing
+570 tests. Simulation: wired power with inverse-time breakers, a diffusing
 heat field with part-load cooling, a shared chilled-water loop metered for
 water on a WUE, UPS buffers, standby generators with fuel, grid sags,
 per-substation outages, time-of-use and peak tariffs, droughts, peak shaving

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ real playthrough.
 ## Status
 
 Thirteen campaign levels across five chapters plus The Lab, nine buildings,
-560 tests. Simulation: wired power with inverse-time breakers, a diffusing
+567 tests. Simulation: wired power with inverse-time breakers, a diffusing
 heat field with part-load cooling, a shared chilled-water loop metered for
 water on a WUE, UPS buffers, standby generators with fuel, grid sags,
 per-substation outages, time-of-use and peak tariffs, droughts, peak shaving

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ elapsedGameTime += dt          (skipped while the tutorial is active)
 ```
 
 The order encodes causality. Nothing asserts it: the loop is hand-copied into
-17 test files, 47 copies in all, so reordering `game.js` leaves the whole
+17 test files, 50 copies in all, so reordering `game.js` leaves the whole
 suite green while the shipped game behaves differently. Those two numbers are
 themselves pinned by `tests/docs-counts.test.mjs` — they drifted four times
 before anyone noticed, which is the same argument this file makes for

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ elapsedGameTime += dt          (skipped while the tutorial is active)
 ```
 
 The order encodes causality. Nothing asserts it: the loop is hand-copied into
-17 test files, 44 copies in all, so reordering `game.js` leaves the whole
+17 test files, 47 copies in all, so reordering `game.js` leaves the whole
 suite green while the shipped game behaves differently. Those two numbers are
 themselves pinned by `tests/docs-counts.test.mjs` — they drifted four times
 before anyone noticed, which is the same argument this file makes for

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -236,7 +236,12 @@ export const CONFIG = {
     // ---- Economy ------------------------------------------------------
     economy: {
         startMoney: 800,
-        powerCostPerKwh: 0.9,    // paid on TOTAL facility draw — PUE in the wallet
+        // Paid on the facility draw that actually came off a UTILITY FEED
+        // (STATE.gridKw) — PUE in the wallet, because every inefficiency
+        // upstream of a rack is drawn through the same meter. What a
+        // generator or a battery carried is not on this line: those are paid
+        // for in fuel and in the recharge respectively.
+        powerCostPerKwh: 0.9,
         bankruptcyAt: -500,
         slaPenaltyPerKwhMissed: 1.5,
         // ---- The water meter, a SECOND utility ------------------------

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -56,9 +56,18 @@ export const STATE = {
                              // draw; PUE's numerator, UNCHANGED in meaning by
                              // peak shaving (see batteryKw below)
     // kW of totalDrawKw sourced from a UPS buffer THIS tick (peak shaving),
-    // not from the grid. sim/demand.js bills (totalDrawKw - batteryKw) —
-    // the meter, not the facility-draw/PUE number, is what shaving touches.
+    // not from the grid. The HUD reads it to show what the toggle is saving;
+    // the meter no longer subtracts it, because gridKw below already counts
+    // only what came off a feed.
     batteryKw: 0,
+    // kW of totalDrawKw that actually came THROUGH A LIVE GRID FEED this
+    // tick — the only quantity a utility may bill, and what sim/demand.js
+    // bills. Everything else the facility drew came out of a generator or a
+    // battery, both of which already pay for themselves (fuel, and the
+    // recharge). Derived from the topology in sim/power.js, never from the
+    // outage flag: a scoped outage and a generator-fed room on a perfectly
+    // healthy grid are the same question, and only the topology answers both.
+    gridKw: 0,
 
     // economy & standing
     money: CONFIG.economy.startMoney,
@@ -164,6 +173,7 @@ export function resetState() {
     STATE.itDrawKw = 0;
     STATE.totalDrawKw = 0;
     STATE.batteryKw = 0;
+    STATE.gridKw = 0;
     STATE.money = CONFIG.economy.startMoney;
     STATE.reputation = CONFIG.sla.startReputation;
     STATE.heatwave = { active: false, endsAt: 0, nextAt: CONFIG.events.heatwave.firstAtSec };

--- a/src/sim/demand.js
+++ b/src/sim/demand.js
@@ -255,13 +255,24 @@ export function tickDemand(dt, elapsed) {
     STATE.tariff.band = STATE.tariff.cycleOn ? band.key : null;
     const tariffMul = (STATE.tariff.active ? STATE.tariff.multiplier : 1) * STATE.tariff.cycleMul;
     STATE.money += STATE.servedKw * CONFIG.buildings.rack.revenuePerKwhServed * billingHours;
-    // PEAK SHAVING (sim/power.js, STATE.peakShave): kW served from a UPS
-    // buffer this tick already left the grid — battery-sourced draw does
-    // not hit the meter, which is the entire point of the mechanic.
-    // totalDrawKw itself is untouched (still every watt the facility drew,
-    // whatever it came from — PUE's numerator stays honest); only the BILL
-    // subtracts it, here and nowhere else.
-    const billedDrawKw = Math.max(0, STATE.totalDrawKw - STATE.batteryKw);
+    // THE UTILITY BILLS WHAT THE UTILITY DELIVERED. STATE.gridKw is the part
+    // of the facility's draw that actually came through a live grid feed
+    // this tick (sim/power.js walks the chain and knows each node's root);
+    // everything else came out of a generator or a battery. Those two are
+    // not free — the generator pays in fuel, the battery in the recharge the
+    // charger buys back on this same meter — so billing them here as well
+    // charged the player twice for energy no utility ever delivered.
+    //
+    // This is also what makes peak shaving pay: shaved kW are displaced out
+    // of gridKw at the UPS, so the credit needs no separate subtraction.
+    // totalDrawKw is untouched (still every watt the facility drew, whatever
+    // it came from — PUE's numerator stays honest); only the BILL narrows.
+    //
+    // Deliberately NOT keyed off STATE.gridOutage.active: a scoped outage
+    // leaves half the room on a live substation, and a room running on a
+    // generator with the grid perfectly healthy is the same question. Only
+    // the topology answers both, and power.js is where the topology lives.
+    const billedDrawKw = Math.max(0, STATE.gridKw);
     STATE.money -= billedDrawKw * eco.powerCostPerKwh * tariffMul * billingHours;
     // WATER — a SECOND utility, on the same meter path and the same billing
     // scale. STATE.water.litersPerHour is written by sim/heat.js, which runs

--- a/src/sim/power.js
+++ b/src/sim/power.js
@@ -9,10 +9,23 @@
 //                       tick for the same reason the battery credit is: the
 //                       standby wave resolves a subtree twice and the second
 //                       resolution has to replace the first, not add to it.
+//   STATE.gridKw      — of totalDrawKw, how much actually came THROUGH A
+//                       LIVE GRID FEED this tick. This is what sim/demand.js
+//                       bills, and the only thing a utility may bill: the
+//                       rest came off a generator (already paid for in fuel)
+//                       or out of a battery (already paid for in the
+//                       recharge). "Grid" enters the model in exactly one
+//                       place — a source of type grid_feed that is not dark
+//                       — and rides down the chain like the credit below, so
+//                       a SCOPED outage and a generator-fed room on a
+//                       perfectly healthy grid both come out right without
+//                       anything reading STATE.gridOutage.
 //   STATE.batteryKw   — of totalDrawKw, how much was served from a UPS
 //                       buffer this tick (peak shaving) rather than the
-//                       grid. sim/demand.js bills (totalDrawKw - batteryKw);
-//                       totalDrawKw/PUE do not change meaning — see below.
+//                       grid. The HUD's signal for what the toggle is
+//                       saving; the meter does not subtract it, because
+//                       shaving displaces the kW out of gridKw where it
+//                       happens. totalDrawKw/PUE do not change meaning.
 //                       Banked at the LOADS that consumed it, never once per
 //                       UPS traversed: ups -> ups is a legal edge, and
 //                       crediting per UPS bills a two-deep chain twice. Held
@@ -25,7 +38,13 @@
 //   actualKw, powered  — per-tick resolution results (links carry, loads draw)
 //   bufferLeft         — UPS buffer seconds remaining
 //   bufferOwedKws      — kW.s that actually left the battery and must be
-//                        bought back; what the charger works down
+//                        bought back; what the charger works down. For the
+//                        outage bridge it is booked in 5c, AFTER the standby
+//                        wave, off what the UPS ended up carrying — a
+//                        generator taking half a bridged subtree means the
+//                        battery never handed that half over, and billing
+//                        the pre-transfer pull made the recharge cost
+//                        multiples of the outage that caused it.
 //   rechargeReqKw      — the charger's request, folded into the pull so the
 //                        link above the UPS has to carry it
 //   upsMode            — "idle" | "charging" | "shaving" | "bridging"
@@ -274,6 +293,17 @@ export function resolvePower(dt) {
     // overwrites exactly what it re-resolves and nothing else.
     const battCredit = new Map();
     const chargerDraw = new Map();
+    // Of what each node consumed, how much came THROUGH A LIVE GRID FEED —
+    // the only kW a utility may bill. Banked per node under exactly the same
+    // rule as the credit, and for the same reason.
+    const gridDraw = new Map();
+    // Seconds each bridging UPS drained this tick. The ENERGY behind them is
+    // NOT booked here: the standby wave below may still take part of a
+    // bridged subtree onto a generator, and bufferOwedKws is "what actually
+    // left the battery", not "what the subtree pulled before the transfer
+    // switch closed". Booked in 5c, once the wave has finished moving load.
+    // Banked per node for the same reason as the two maps above.
+    const bridgeDrain = new Map();
 
     // 1) Sanitized load requests.
     const requests = new Map();
@@ -363,7 +393,7 @@ export function resolvePower(dt) {
     // may sit under another UPS, and crediting each one as it is traversed
     // bills a two-deep chain twice and lets the un-buffered half of the room
     // ride free behind demand.js's clamp.
-    function deliver(b, live, grantKw, grantBattKw = 0) {
+    function deliver(b, live, grantKw, grantBattKw = 0, grantGridKw = 0) {
         if (visited.has(b.id)) return;
         visited.add(b.id);
         // Whatever this node banked on an earlier pass is void the moment it
@@ -372,6 +402,8 @@ export function resolvePower(dt) {
         // was billed against.
         battCredit.delete(b.id);
         chargerDraw.delete(b.id);
+        gridDraw.delete(b.id);
+        bridgeDrain.delete(b.id);
         const pull = pullOf(b);
 
         if (b.config.chainRole === "load") {
@@ -380,6 +412,10 @@ export function resolvePower(dt) {
             b.powered = live && (got > 0 || pull === 0);
             // THE ONE PLACE a load banks battery credit.
             if (got > 0 && grantBattKw > 0) battCredit.set(b.id, Math.min(got, grantBattKw));
+            // ...and the one place it banks METERED draw, for the same
+            // reason: a kW is counted where it is consumed, never once per
+            // link it travelled through.
+            if (got > 0 && grantGridKw > 0) gridDraw.set(b.id, Math.min(got, grantGridKw));
             return;
         }
 
@@ -390,6 +426,22 @@ export function resolvePower(dt) {
         let outBattKw = 0;
         if (outKw > 0 && grantBattKw > 0 && Number.isFinite(grantKw) && grantKw > 0) {
             outBattKw = Math.min(outKw, grantBattKw * Math.min(1, outKw / grantKw));
+        }
+        // Metered share of what this link carries, clipped the same way. It
+        // ENTERS the model in exactly one place — a live grid feed — and a
+        // root's grant is Infinity, so a source names its own share outright
+        // instead of taking a fraction of one. That single entry point is
+        // what makes the answer right for a SCOPED outage (the dark feed
+        // contributes nothing, its healthy neighbour still does) and for a
+        // generator-fed room on a perfectly healthy grid, neither of which
+        // an `if (gridOutage.active)` special case could tell apart.
+        let outGridKw = 0;
+        if (outKw > 0) {
+            if (b.config.chainRole === "source") {
+                outGridKw = b.type === "grid_feed" ? outKw : 0;
+            } else if (grantGridKw > 0 && Number.isFinite(grantKw) && grantKw > 0) {
+                outGridKw = Math.min(outKw, grantGridKw * Math.min(1, outKw / grantKw));
+            }
         }
         // What this node draws from its PARENT. Identical to outKw for
         // everything except a charging UPS, which also draws its charger.
@@ -418,6 +470,12 @@ export function resolvePower(dt) {
                 let battOut = Math.min(served, outBattKw);
                 const spare = Math.max(0, outKw - served);
                 const battSpare = Math.max(0, outBattKw - battOut);
+                // The metered share splits in the same order: the subtree is
+                // served first and the charger lives on what is left. Battery
+                // kW are allocated to the load first, so the meter covers
+                // only what the battery did not.
+                let gridOut = Math.min(Math.max(0, served - battOut), outGridKw);
+                const gridSpare = Math.max(0, outGridKw - gridOut);
                 let chargeKw = 0;
 
                 if (STATE.peakShave.on && b.bufferLeft > 0 && served > battOut) {
@@ -438,6 +496,10 @@ export function resolvePower(dt) {
                     b.bufferLeft -= useSec;
                     b.bufferOwedKws += fromBattery * dt;
                     battOut += fromBattery;
+                    // Shaving DISPLACES metered kW — the same kW to the same
+                    // racks, bought from the battery instead of the meter —
+                    // so whatever it displaces stops being grid-sourced.
+                    gridOut = Math.max(0, gridOut - fromBattery);
                     b.upsMode = fromBattery > 0 ? "shaving" : "idle";
                 } else if ((b.rechargeReqKw || 0) > 0 && spare > 0 && b.bufferLeft < max) {
                     // RECHARGE. The charger draws what its rating and its
@@ -461,6 +523,11 @@ export function resolvePower(dt) {
                         if (battSpare > 0 && chargeKw > 0) {
                             battCredit.set(b.id, Math.min(chargeKw, battSpare * (chargeKw / spare)));
                         }
+                        // ...and so is the metered part of it. A charger
+                        // running off a generator is fuel, not a bill.
+                        if (gridSpare > 0 && chargeKw > 0) {
+                            gridDraw.set(b.id, Math.min(chargeKw, gridSpare * (chargeKw / spare)));
+                        }
                         b.upsMode = "charging";
                     } else {
                         b.upsMode = "idle";
@@ -471,6 +538,7 @@ export function resolvePower(dt) {
 
                 outKw = served;
                 outBattKw = battOut;
+                outGridKw = gridOut;
                 carriedKw = served + chargeKw;
             } else if (b.bufferLeft > 0) {
                 // The outage bridge, unchanged: seconds are spent at the
@@ -484,14 +552,23 @@ export function resolvePower(dt) {
                 if (subtreePull > 0) {
                     const drainedSec = Math.min(dt, b.bufferLeft);
                     b.bufferLeft -= drainedSec;
-                    b.bufferOwedKws += subtreePull * drainedSec;
+                    // SECONDS now, ENERGY at 5c. Booking `subtreePull *
+                    // drainedSec` here charges the battery for the whole
+                    // PRE-TRANSFER subtree, and the standby wave has not run
+                    // yet — a generator picking up half this subtree left
+                    // the UPS owing for load it never ended up carrying, and
+                    // the charger then bought that inflated figure back on
+                    // the meter.
+                    bridgeDrain.set(b.id, drainedSec);
                 }
                 outBattKw = 0; // bridged load is not peak shaving; see demand.js
+                outGridKw = 0; // ...and it is the battery, not the meter
                 carriedKw = outKw;
                 b.upsMode = "bridging";
             } else {
                 outKw = 0;
                 outBattKw = 0;
+                outGridKw = 0;
                 carriedKw = 0;
                 b.upsMode = "idle";
             }
@@ -507,6 +584,7 @@ export function resolvePower(dt) {
             outLive = false;
             outKw = 0;
             outBattKw = 0;
+            outGridKw = 0;
             carriedKw = 0;
         }
 
@@ -526,7 +604,7 @@ export function resolvePower(dt) {
         const childLive = outLive && (outKw > 0 || totalChildPull === 0);
         for (const c of kids) {
             const frac = totalChildPull > 0 ? pullOf(c) / totalChildPull : 0;
-            deliver(c, childLive, outKw * frac, outBattKw * frac);
+            deliver(c, childLive, outKw * frac, outBattKw * frac, outGridKw * frac);
         }
     }
 
@@ -578,26 +656,62 @@ export function resolvePower(dt) {
         }
         return false;
     };
+
+    // Every fueled generator's transfer candidates, gathered BEFORE any of
+    // them delivers. coveredByEarlierWave above walks a candidate's PARENTS
+    // looking for an already-redelivered node, so it can only ever see a
+    // candidate BELOW a wave that has already run. When the deeper
+    // generator's wave runs first, the shallower generator's candidate is an
+    // ANCESTOR of the redelivered set, that walk never sees it, and both
+    // generators deliver — and burn fuel for — the same racks. Which of the
+    // two happened depended on nothing but STATE.buildings order.
+    const rawCandidates = new Map();
     for (const g of STATE.buildings) {
-        if (g.type !== "generator") continue;
-        const candidates = [];
+        if (g.type !== "generator" || g.fuelLiters <= 0) continue;
+        const list = [];
         for (const b of STATE.buildings) {
-            if (b.standbyParentId === g.id && primaryPathDead(b, byId)
-                && !coveredByEarlierWave(b) && pullOf(b) > 0) {
-                candidates.push(b);
+            if (b.standbyParentId === g.id && primaryPathDead(b, byId) && pullOf(b) > 0) {
+                list.push(b);
             }
         }
-        // Intra-generator dedup: keep only the topmost of nested candidates.
-        const candidateIds = new Set(candidates.map((c) => c.id));
-        const standbys = candidates.filter((c) => {
-            let node = byId.get(c.parentId);
-            let hops = 0;
-            while (node && ++hops <= STATE.buildings.length) {
-                if (candidateIds.has(node.id)) return false;
-                node = node.parentId && node.parentId !== "grid" ? byId.get(node.parentId) : null;
-            }
-            return true;
-        });
+        if (list.length > 0) rawCandidates.set(g.id, list);
+    }
+    const candidateOwner = new Map();
+    for (const [gid, list] of rawCandidates) {
+        for (const c of list) candidateOwner.set(c.id, gid);
+    }
+    // When a generator is ready to carry, measured AFTER this tick's cutover
+    // step. Comparing post-decrement clocks is what makes the handover
+    // atomic: the shallower switch picks up on the same tick the deeper one
+    // lets go, so the racks are never carried twice and never dropped in
+    // between. A generator whose switch is still counting down cannot
+    // supersede one that is already carrying — wiring a second generator
+    // ABOVE a working one must not black the room out for a cutover.
+    const readyAt = (gid) => Math.max(0, byId.get(gid).cutoverLeft - dt);
+    // THE TOPMOST TRANSFER POINT WINS. This is the rule the wave already
+    // applied between ONE generator's nested candidates ("keep only the
+    // topmost"); applying it between generators too is what makes the answer
+    // independent of placement order. Nothing loses coverage — the shallower
+    // point's subtree strictly contains the deeper one's — and the
+    // superseded generator simply idles with its cutover clock reset,
+    // exactly as a covered candidate has always left it.
+    const supersededByShallower = (c) => {
+        const mine = readyAt(candidateOwner.get(c.id));
+        let node = c.parentId && c.parentId !== "grid" ? byId.get(c.parentId) : null;
+        let hops = 0;
+        while (node && ++hops <= STATE.buildings.length) {
+            const owner = candidateOwner.get(node.id);
+            if (owner !== undefined && readyAt(owner) <= mine) return true;
+            node = node.parentId && node.parentId !== "grid" ? byId.get(node.parentId) : null;
+        }
+        return false;
+    };
+
+    for (const g of STATE.buildings) {
+        if (g.type !== "generator") continue;
+        const standbys = (rawCandidates.get(g.id) || []).filter(
+            (c) => !supersededByShallower(c) && !coveredByEarlierWave(c)
+        );
         if (standbys.length === 0 || g.fuelLiters <= 0) {
             g.cutoverLeft = g.config.cutoverSec;
             continue;
@@ -671,17 +785,52 @@ export function resolvePower(dt) {
             }
             return false;
         };
+        // Did the wave reach anywhere inside this branch? A link BETWEEN a
+        // bridging UPS and the transfer point is left holding a pre-transfer
+        // actualKw for exactly the same reason the UPS is, so the carry has
+        // to be rebuilt from the children rather than read off any one link.
+        const waveTouched = (node) => {
+            for (const cid of node.childIds) {
+                const k = byId.get(cid);
+                if (!k) continue;
+                if (redelivered.has(k.id) || waveTouched(k)) return true;
+            }
+            return false;
+        };
+        // What a bridging UPS STILL hands down once the wave has taken part
+        // of its subtree: the branches it still feeds, at this tick's
+        // delivered numbers, plus any charger running inside them (banked
+        // per node above, and drawn from this UPS like any other load).
+        const stillOnBridgeKw = (node) => {
+            let sum = chargerDraw.get(node.id) || 0;
+            for (const cid of node.childIds) {
+                const k = byId.get(cid);
+                if (!k || redelivered.has(k.id)) continue;
+                sum += waveTouched(k) ? stillOnBridgeKw(k) : k.actualKw;
+            }
+            return sum;
+        };
         for (const c of STATE.buildings) {
             if (!c.standbyParentId || !redelivered.has(c.id)) continue;
             let node = byId.get(c.parentId);
             let hops = 0;
             while (node && ++hops <= STATE.buildings.length) {
                 if (node.type === "ups" && node.upsMode === "bridging"
-                    && !redelivered.has(node.id)
-                    && !carriesOutsideRedelivered(node)) {
-                    node.bufferLeft = bufSnap.get(node.id).sec;
-                    node.bufferOwedKws = bufSnap.get(node.id).owed;
-                    node.actualKw = 0;
+                    && !redelivered.has(node.id)) {
+                    if (!carriesOutsideRedelivered(node)) {
+                        node.bufferLeft = bufSnap.get(node.id).sec;
+                        node.bufferOwedKws = bufSnap.get(node.id).owed;
+                        node.actualKw = 0;
+                    } else {
+                        // PARTIAL transfer. The generator took some of this
+                        // bridge's subtree and left the rest, so the bridge
+                        // is still carrying and still spending SECONDS — but
+                        // only over what it actually still feeds. Leaving the
+                        // pre-transfer figure here is what billed a battery
+                        // for racks a generator was carrying, and then billed
+                        // the recharge back on the inflated number.
+                        node.actualKw = stillOnBridgeKw(node);
+                    }
                 }
                 node = node.parentId && node.parentId !== "grid" ? byId.get(node.parentId) : null;
             }
@@ -713,6 +862,22 @@ export function resolvePower(dt) {
         } else {
             b.breakerHeat = Math.max(0, b.breakerHeat - dt * brk.coolPerSec);
         }
+    }
+
+    // 5c) THE BRIDGE'S ENERGY BOOK, after the wave has finished moving load.
+    // bufferLeft counts SECONDS and the bridge spends them at the UPS's full
+    // rating however little it carries; bufferOwedKws counts the ENERGY that
+    // actually left, and that is the one the charger buys back on the meter.
+    // Two different quantities, and only the second one may follow the load —
+    // booking it against the pre-transfer subtree pull up in deliver() is how
+    // one physical discharge ended up with two numbers describing it.
+    for (const [id, drainedSec] of bridgeDrain) {
+        const b = byId.get(id);
+        // Still bridging: a UPS the wave re-delivered took the live branch on
+        // its second pass and had its buffer rolled back to the snapshot, so
+        // there is no discharge left to book.
+        if (!b || b.upsMode !== "bridging") continue;
+        b.bufferOwedKws += Math.max(0, b.actualKw) * drainedSec;
     }
 
     // 6) Fuel burn (billing scale: one game minute = one billing hour) and
@@ -749,4 +914,11 @@ export function resolvePower(dt) {
     let batterySum = 0;
     for (const kw of battCredit.values()) batterySum += kw;
     STATE.batteryKw = batterySum;
+    // What the UTILITY actually delivered, and therefore all it may bill.
+    // Summed the same way, once, over the LAST resolution of every node —
+    // a subtree the standby wave re-delivered came off the generator, and
+    // the generator is already paying for it in fuel.
+    let gridSum = 0;
+    for (const kw of gridDraw.values()) gridSum += kw;
+    STATE.gridKw = gridSum;
 }

--- a/tests/demand.test.mjs
+++ b/tests/demand.test.mjs
@@ -201,7 +201,8 @@ describe("economy", () => {
         const pdu = makeFeedAndPdu();
         addRack(pdu, 2).actualKw = 6;
         addRack(pdu, 3).actualKw = 6;
-        STATE.totalDrawKw = 5;              // last tick's facility bill basis
+        STATE.totalDrawKw = 5;              // last tick's facility draw
+        STATE.gridKw = 5;                   // ...all of it off the feed, so all billable
         tickDemand(60, 0);                  // one game minute = one billing hour
         // revenue 4 kW * $3/kWh - cost 5 kW * $0.9/kWh, no SLA miss
         expect(STATE.money).toBeCloseTo(CONFIG.economy.startMoney + 12 - 4.5, 6);
@@ -210,6 +211,7 @@ describe("economy", () => {
 
     it("bleeds money on idle draw: power bill plus SLA penalty", () => {
         STATE.totalDrawKw = 3;              // a CRAC idling, nothing served
+        STATE.gridKw = 3;                   // idling ON THE UTILITY, so the meter runs
         tickDemand(6, 0);                   // demand 4, served 0
         const expected = CONFIG.economy.startMoney
             - 3 * CONFIG.economy.powerCostPerKwh * 6 / 60

--- a/tests/generator.test.mjs
+++ b/tests/generator.test.mjs
@@ -160,6 +160,63 @@ describe("standby double-count guards", () => {
         expect(burners.length).toBe(1);
     });
 
+    // THE SAME ROOM, BUILT IN THE OTHER ORDER. The test above wires the
+    // SHALLOW generator first and passes; the guard it leans on walks a
+    // candidate's PARENTS looking for an already-redelivered node, so it can
+    // only ever see a candidate BELOW a wave that has already run. Place the
+    // DEEP generator first and its wave goes first, the shallow generator's
+    // candidate is an ANCESTOR of the redelivered set, that walk never sees
+    // it, and both machines deliver — and buy diesel for — the same two
+    // racks. Which of the two you got depended on nothing a player can see:
+    // the order the buildings happen to sit in STATE.buildings.
+    it("WHICH GENERATOR YOU PLACED FIRST is not a physical fact — the room burns the same fuel either way", () => {
+        function room(deepFirst) {
+            resetState();
+            resetBuildingIds();
+            STATE.heatwave.nextAt = Infinity;
+            STATE.brownout.nextAt = Infinity;
+            STATE.breakdown.nextAt = Infinity;
+            STATE.gridOutage.nextAt = Infinity;
+            STATE.contract.nextAt = Infinity;
+            STATE.demandFixedKw = 10;
+            const { xf, pdu } = chain(5);
+            [place("rack", 14, 5), place("rack", 14, 7)].forEach((r) => wireBuildings(pdu, r));
+            // The ONLY difference between the two runs.
+            const gDeep = deepFirst ? place("generator", 2, 11) : null;
+            const gShallow = place("generator", 2, 8);
+            const deep = gDeep || place("generator", 2, 11);
+            wireBuildings(gShallow, xf);   // the shallow transfer point
+            wireBuildings(deep, pdu);      // ...and one inside its own subtree
+            run(5);
+            STATE.gridOutage.active = true;
+            STATE.gridOutage.endsAt = Infinity;
+            run(20);
+            return {
+                burned: (gShallow.config.tankLiters - gShallow.fuelLiters)
+                    + (deep.config.tankLiters - deep.fuelLiters),
+                carried: gShallow.actualKw + deep.actualKw,
+                served: STATE.servedKw,
+                burners: [gShallow, deep].filter((g) => g.fuelLiters < g.config.tankLiters - 1e-9).length,
+            };
+        }
+
+        const shallowFirst = room(false);
+        const deepFirst = room(true);
+
+        // The racks are served either way — the fix must not buy its honesty
+        // by dropping the load the shallower switch was there to pick up.
+        expect(shallowFirst.served).toBeCloseTo(10, 0);
+        expect(deepFirst.served).toBeCloseTo(10, 0);
+        // ONE machine carries the subtree, and ONE machine pays for it.
+        expect(shallowFirst.burners).toBe(1);
+        expect(deepFirst.burners).toBe(1);
+        expect(deepFirst.carried).toBeLessThan(15);      // one subtree's pull, once
+        // ...and the tank reads the same to the drop, because placement
+        // order is not a physical fact about a datacenter.
+        expect(deepFirst.burned).toBeCloseTo(shallowFirst.burned, 9);
+        expect(deepFirst.burned).toBeGreaterThan(0);
+    });
+
     it("an ancestor UPS stops draining once the generator carries everything below it", () => {
         // Standby attached BELOW the UPS: chain feed→xf→ups→pdu, generator
         // standby to the PDU. During the outage the UPS bridges the cutover,

--- a/tests/peak-shaving.test.mjs
+++ b/tests/peak-shaving.test.mjs
@@ -1006,6 +1006,80 @@ describe("measured in-game: one full discharge at day x peak, recharged at night
 // re-delivered subtree's buffers back to the snapshot and kept the credit
 // anyway. Each was found by a person reading the code, one at a time, after
 // it had already shipped. This is that reading, done every tick.
+// THE OTHER DIRECTION. Every clause of the ledger invariant below reads
+// `x > y`: they catch a meter or a booking that charges TOO MUCH, which is
+// unfair, and say nothing about one that charges too little — which is free
+// energy, and worse. These pin the floor for the topologies a player actually
+// builds: with no generator and no battery discharging, the utility delivered
+// every kW the facility drew, so gridKw and totalDrawKw are the same number.
+//
+// (The chaotic run below cannot carry this clause yet: a bridge that runs its
+// buffer to zero hands out one final tick it no longer has — carried 6 kW,
+// booked 0 — which shows up here as an under-bill. That is a real defect, it
+// predates gridKw, and it is written up rather than papered over with a
+// tolerance wide enough to hide it.)
+describe("the meter's floor: kW nobody paid for is free energy", () => {
+    it("a plain grid-fed room bills every kW it drew", () => {
+        const feed = place("grid_feed", 2, 5);
+        const t = place("transformer", 5, 5);
+        const pdu = place("pdu", 8, 5);
+        wireBuildings(feed, t); wireBuildings(t, pdu);
+        for (let i = 0; i < 3; i++) {
+            const r = place("rack", 11 + i, 5);
+            wireBuildings(pdu, r);
+            r.assignedKw = CONFIG.buildings.rack.capacityKw;
+        }
+        for (let k = 0; k < 40; k++) resolvePower(DT);
+        expect(STATE.totalDrawKw).toBeGreaterThan(0);
+        expect(STATE.batteryKw).toBe(0);
+        expect(STATE.gridKw).toBeCloseTo(STATE.totalDrawKw, 9);
+    });
+
+    it("a UPS in the chain with shaving OFF bills the racks AND its charger", () => {
+        const feed = place("grid_feed", 2, 5);
+        const t = place("transformer", 5, 5);
+        const ups = place("ups", 8, 5);
+        const pdu = place("pdu", 11, 5);
+        wireBuildings(feed, t); wireBuildings(t, ups); wireBuildings(ups, pdu);
+        for (let i = 0; i < 3; i++) {
+            const r = place("rack", 14 + i, 5);
+            wireBuildings(pdu, r);
+            r.assignedKw = CONFIG.buildings.rack.capacityKw;
+        }
+        for (let k = 0; k < 40; k++) resolvePower(DT);
+        expect(STATE.totalDrawKw).toBeGreaterThan(0);
+        expect(STATE.gridKw).toBeCloseTo(STATE.totalDrawKw, 9);
+    });
+
+    it("a generator branch beside a grid branch: each kW billed to its own source", () => {
+        const feed = place("grid_feed", 2, 5);
+        const t = place("transformer", 5, 5);
+        const pduA = place("pdu", 8, 5);
+        wireBuildings(feed, t); wireBuildings(t, pduA);
+        for (let i = 0; i < 2; i++) {
+            const r = place("rack", 11 + i, 5);
+            wireBuildings(pduA, r);
+            r.assignedKw = CONFIG.buildings.rack.capacityKw;
+        }
+        const gen = place("generator", 2, 15);
+        const pduB = place("pdu", 8, 15);
+        wireBuildings(gen, pduB);
+        for (let i = 0; i < 2; i++) {
+            const r = place("rack", 11 + i, 15);
+            wireBuildings(pduB, r);
+            r.assignedKw = CONFIG.buildings.rack.capacityKw;
+        }
+        for (let k = 0; k < 60; k++) resolvePower(DT);
+        const gens = STATE.buildings
+            .filter((b) => b.type === "generator")
+            .reduce((s, b) => s + Math.max(0, b.actualKw), 0);
+        expect(gens).toBeGreaterThan(0);
+        // Nothing drawn off-meter, and nothing billed that diesel produced.
+        expect(STATE.gridKw + gens).toBeCloseTo(STATE.totalDrawKw, 9);
+        expect(STATE.gridKw).toBeCloseTo(STATE.totalDrawKw - gens, 9);
+    });
+});
+
 describe("THE LEDGER: a credited kW.s came out of a battery, or it did not happen", () => {
     // Every UPS keeps two independent books on the same physical event: the
     // CHARGE it gave up (bufferLeft, denominated in seconds of capacityKw)

--- a/tests/peak-shaving.test.mjs
+++ b/tests/peak-shaving.test.mjs
@@ -21,7 +21,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { CONFIG } from "../src/core/config.js";
 import { STATE, resetState } from "../src/core/state.js";
 import { Building, resetBuildingIds } from "../src/entities/Building.js";
-import { resolvePower, unwire, wireBuildings } from "../src/sim/power.js";
+import { feedIsDark, resolvePower, unwire, wireBuildings } from "../src/sim/power.js";
 import { tickDemand, tickEvents } from "../src/sim/demand.js";
 import { tickHeat } from "../src/sim/heat.js";
 import { tickContracts } from "../src/sim/contracts.js";
@@ -453,21 +453,111 @@ describe("batteryKw is credited ONCE per delivered kW, not once per UPS", () => 
 });
 
 describe("sim/demand.js bills grid-sourced draw only", () => {
-    it("THE FORMULA: money is charged on (totalDrawKw - batteryKw), not totalDrawKw", () => {
-        // Isolate the billing arithmetic from power.js entirely: pin
-        // totalDrawKw/batteryKw by hand and zero out demand so revenue and
-        // SLA terms drop out, leaving only the power-cost term to compare.
+    it("THE FORMULA: the meter charges what came off the GRID, not what the facility drew", () => {
+        // Isolate the billing arithmetic from power.js entirely: pin the
+        // draw split by hand and zero out demand so revenue and SLA terms
+        // drop out, leaving only the power-cost term to compare. power.js is
+        // what displaces shaved kW out of gridKw — the whole-loop proof of
+        // that is the per-tick invariant at the bottom of this file.
         STATE.demandFixedKw = 0;
-        STATE.totalDrawKw = 20;
-        STATE.batteryKw = 12;
+        // Three sources, three prices. The split is deliberately one no
+        // single subtraction can reproduce: a meter that charged
+        // (totalDrawKw - batteryKw) would bill 8 here, not 5, because a
+        // generator is not a battery and neither of them is the utility.
+        STATE.totalDrawKw = 20;     // the facility drew 20 — PUE's numerator
+        STATE.batteryKw = 12;       // 12 of it came out of a battery
+        STATE.gridKw = 5;           // 5 off a feed; the other 3 off diesel
         STATE.tariff.active = true;
         STATE.tariff.multiplier = 2;
         STATE.tariff.endsAt = Infinity;
         const before = STATE.money;
         tickDemand(DT, 1);
-        const billedKw = STATE.totalDrawKw - STATE.batteryKw; // 8, unless demand.js mutated them
-        const expected = -(billedKw * CONFIG.economy.powerCostPerKwh * STATE.tariff.multiplier * (DT / 60));
-        expect(STATE.money - before).toBeCloseTo(expected, 9);
+        const perKw = CONFIG.economy.powerCostPerKwh * STATE.tariff.multiplier * (DT / 60);
+        expect(STATE.money - before).toBeCloseTo(-(STATE.gridKw * perKw), 9);
+        // ...and neither the facility draw nor the draw-minus-battery is
+        // what was charged, which is the whole claim.
+        expect(STATE.money - before).not.toBeCloseTo(-(STATE.totalDrawKw * perKw), 9);
+        expect(STATE.money - before).not.toBeCloseTo(
+            -((STATE.totalDrawKw - STATE.batteryKw) * perKw), 9
+        );
+    });
+
+    // THE LESSON THIS LEVEL EXISTS FOR: a generator and a battery are how
+    // you stop paying the utility for a while. The meter used to charge the
+    // whole facility draw through a total blackout — the diesel the
+    // generator was burning, and the kW coming out of a UPS — so the room
+    // paid the city for energy the city had visibly stopped delivering, on
+    // top of the fuel and the recharge it was already paying for.
+    it("A UTILITY CANNOT BILL YOU FOR A BLACKOUT: nothing came off the meter, so nothing is charged", () => {
+        STATE.demandFixedKw = 12;
+        // One room on a generator, one behind a UPS buffer. No grid feed is
+        // alive for either of them.
+        const gen = place("generator", 2, 2);
+        const pduG = place("pdu", 5, 2);
+        wireBuildings(gen, pduG);
+        for (let i = 0; i < 2; i++) wireBuildings(pduG, place("rack", 8, 2 + i));
+        const feed = place("grid_feed", 2, 10);
+        const ups = place("ups", 5, 10);
+        const pduU = place("pdu", 8, 10);
+        wireBuildings(feed, ups);
+        wireBuildings(ups, pduU);
+        wireBuildings(pduU, place("rack", 11, 10));
+
+        STATE.gridOutage.active = true;
+        STATE.gridOutage.endsAt = Infinity;
+        STATE.gridOutage.scope = "all";
+
+        let charged = 0;
+        let drew = 0;
+        let servedTicks = 0;
+        runFull(6, () => {
+            charged += STATE.gridKw;
+            drew += STATE.totalDrawKw;
+            if (STATE.itDrawKw > 0) servedTicks++;
+        });
+
+        // The room really did run — on diesel and on stored charge.
+        expect(servedTicks).toBeGreaterThan(100);
+        expect(drew).toBeGreaterThan(0);
+        expect(gen.fuelLiters).toBeLessThan(gen.config.tankLiters);   // fuel paid for it
+        expect(ups.bufferOwedKws).toBeGreaterThan(0);                 // recharge will pay for it
+        // ...and the utility delivered NOT ONE kW, so it billed nothing.
+        expect(charged).toBe(0);
+    });
+
+    // The mirror, and the reason this is not an `if (gridOutage.active)`:
+    // the grid can be perfectly healthy and a room still be off it.
+    it("A ROOM ON A GENERATOR pays in fuel, not on the meter — with the grid perfectly healthy", () => {
+        STATE.demandFixedKw = 24;
+        const gen = place("generator", 2, 2);
+        const pduG = place("pdu", 5, 2);
+        wireBuildings(gen, pduG);
+        for (let i = 0; i < 2; i++) wireBuildings(pduG, place("rack", 8, 2 + i));
+        const feed = place("grid_feed", 2, 10);
+        const pduF = place("pdu", 5, 10);
+        wireBuildings(feed, pduF);
+        const metered = [];
+        for (let i = 0; i < 2; i++) {
+            const r = place("rack", 8, 10 + i);
+            wireBuildings(pduF, r);
+            metered.push(r);
+        }
+
+        let charged = 0;
+        let meteredDraw = 0;
+        let facilityDraw = 0;
+        runFull(6, () => {
+            charged += STATE.gridKw;
+            meteredDraw += metered.reduce((s, x) => s + x.actualKw, 0);
+            facilityDraw += STATE.totalDrawKw;
+        });
+
+        expect(STATE.gridOutage.active).toBe(false);   // nothing is wrong with the grid
+        expect(gen.fuelLiters).toBeLessThan(gen.config.tankLiters);
+        // The meter charged the fed half and ONLY the fed half — half the
+        // facility's draw, to nine decimals.
+        expect(charged).toBeCloseTo(meteredDraw, 9);
+        expect(charged).toBeCloseTo(facilityDraw / 2, 9);
     });
 
     it("batteryKw >= totalDrawKw never bills a negative power cost (clamped)", () => {
@@ -678,6 +768,101 @@ describe("a recharging UPS is a load on its own upstream", () => {
             maxOverhead = Math.max(maxOverhead, STATE.totalDrawKw - STATE.itDrawKw);
         }
         expect(maxOverhead).toBeCloseTo(0, 9);     // not one kW of charger on the meter
+    });
+});
+
+// A UPS bridging an outage spends SECONDS at its full rating however little
+// it is carrying — that is the question the bridge answers, "how long do I
+// have?", and every campaign level is proven against it. bufferOwedKws is a
+// different quantity: the ENERGY that actually left, and the exact figure the
+// charger buys back on the meter. When a transfer switch below the UPS hands
+// part of the bridged subtree to a generator, the battery stops delivering
+// that part — and a book that still says otherwise makes the recharge cost a
+// multiple of the outage that caused it.
+describe("a bridged subtree a GENERATOR took is not energy the battery gave up", () => {
+    // feed -> ups -> transformer -> { pduGen -> 2 racks , pduStay -> 1 rack }
+    // generator --standby--> pduGen
+    function room() {
+        STATE.demandFixedKw = 18;
+        const feed = place("grid_feed", 2, 2);
+        const ups = place("ups", 5, 2);
+        const tr = place("transformer", 8, 2);
+        const pduGen = place("pdu", 11, 2);
+        const pduStay = place("pdu", 11, 8);
+        wireBuildings(feed, ups);
+        wireBuildings(ups, tr);
+        wireBuildings(tr, pduGen);
+        wireBuildings(tr, pduStay);
+        const taken = [];
+        for (let i = 0; i < 2; i++) {
+            const r = place("rack", 14, 2 + i);
+            wireBuildings(pduGen, r);
+            taken.push(r);
+        }
+        const left = [place("rack", 14, 8)];
+        wireBuildings(pduStay, left[0]);
+        const gen = place("generator", 2, 12);
+        wireBuildings(gen, pduGen);
+        return { feed, ups, tr, pduGen, pduStay, taken, left, gen };
+    }
+
+    it("THE BATTERY OWES WHAT IT HANDED OVER, not what the room pulled before the switch closed", () => {
+        const r = room();
+        STATE.gridOutage.active = true;
+        STATE.gridOutage.endsAt = Infinity;
+
+        let booked = 0;
+        let reallyLeft = 0;
+        let afterPickupBooked = 0;
+        let afterPickupReal = 0;
+        let pickupTicks = 0;
+
+        for (let i = 0; i < Math.round(12 / DT); i++) {
+            STATE.elapsedGameTime += DT;
+            const t = STATE.elapsedGameTime;
+            tickEvents(DT, t);
+            tickDemand(DT, t);
+            const owedBefore = r.ups.bufferOwedKws;
+            const secBefore = r.ups.bufferLeft;
+            resolvePower(DT);
+            const drainedSec = secBefore - r.ups.bufferLeft;
+            // GROUND TRUTH, read off the delivered state: the load under this
+            // UPS that the GENERATOR is not carrying. Before the cutover
+            // that is the whole room; after it, only the branch the wave
+            // left behind.
+            const allLoad = [...r.taken, ...r.left].reduce((s, x) => s + x.actualKw, 0);
+            const onBattery = Math.max(0, allLoad - r.gen.actualKw);
+            booked += r.ups.bufferOwedKws - owedBefore;
+            reallyLeft += onBattery * drainedSec;
+            if (r.gen.actualKw > 0) {
+                pickupTicks++;
+                afterPickupBooked += r.ups.bufferOwedKws - owedBefore;
+                afterPickupReal += onBattery * drainedSec;
+            }
+        }
+
+        // The run really went through a cutover with the bridge still live.
+        expect(pickupTicks).toBeGreaterThan(50);
+        expect(afterPickupReal).toBeGreaterThan(0);
+        // The generator took 12 of the 18 kW, so a book that never noticed
+        // charges the battery 3x on every tick after pickup.
+        expect(afterPickupBooked).toBeCloseTo(afterPickupReal, 9);
+        expect(booked).toBeCloseTo(reallyLeft, 9);
+        expect(booked).toBeGreaterThan(0);
+    });
+
+    it("...and the UPS stops REPORTING the kW a generator is carrying", () => {
+        const r = room();
+        STATE.gridOutage.active = true;
+        STATE.gridOutage.endsAt = Infinity;
+        runFull(r.gen.config.cutoverSec + 1);
+        expect(r.gen.actualKw).toBeGreaterThan(0);       // the switch closed
+        expect(r.ups.upsMode).toBe("bridging");          // ...and the bridge is still up
+        // 18 kW before the switch closed, 6 after it. The inspector reads
+        // this field, so a stale one tells the player the battery is
+        // carrying three times what it is.
+        expect(r.ups.actualKw).toBeCloseTo(6, 9);
+        expect(r.left[0].actualKw).toBeCloseTo(6, 9);    // and the branch really is served
     });
 });
 
@@ -925,8 +1110,14 @@ describe("THE LEDGER: a credited kW.s came out of a battery, or it did not happe
     //                                                        above a serviced link
     //   grid_feed -> ups -> ups -> pdu -> 2 racks            a CHARGER inside a
     //   generator --standby--> the upper ups                 re-delivered subtree
+    //   grid_feed -> transformer -> pdu -> 2 racks           TWO TRANSFER
+    //   generator --standby--> that transformer              SWITCHES IN SERIES,
+    //   generator --standby--> that pdu                      deep one placed first
+    //   grid_feed -> ups -> transformer -> pdu -> 2 racks    a bridge only
+    //                              \--> pdu -> 1 rack        PARTLY transferred
+    //   generator --standby--> the first of those pdus
     function facility() {
-        STATE.demandFixedKw = 66;                      // every rack at its full 6 kW
+        STATE.demandFixedKw = 96;                      // every rack at its full 6 kW
         const feedA = place("grid_feed", 2, 5);
         const upsA = place("ups", 5, 5);
         const upsB = place("ups", 8, 5);
@@ -992,7 +1183,50 @@ describe("THE LEDGER: a credited kW.s came out of a battery, or it did not happe
         wireBuildings(upsE, pduE);
         for (let i = 0; i < 2; i++) wireBuildings(pduE, place("rack", 27, 21 + i));
         const gen3 = place("generator", 18, 25);       // wired standby mid-run
-        return { upsA, upsB, upsC, upsD, upsE, gen, gen2, gen3, pduB, trC, armed: false };
+
+        // TWO TRANSFER SWITCHES IN SERIES on one chain: one generator's
+        // candidate is an ANCESTOR of the other's. The DEEP machine is placed
+        // FIRST on purpose — that is the order in which the shallower
+        // candidate is invisible to a guard that only walks a candidate's
+        // parents, and both machines then carry (and buy diesel for) the same
+        // two racks. Placement order is not a physical fact about a room, so
+        // the invariants below have to hold in this order too.
+        const feedE = place("grid_feed", 2, 27);
+        const trE = place("transformer", 5, 27);
+        const pduF = place("pdu", 8, 27);
+        wireBuildings(feedE, trE);
+        wireBuildings(trE, pduF);
+        for (let i = 0; i < 2; i++) wireBuildings(pduF, place("rack", 11, 27 + i));
+        const gen5 = place("generator", 14, 27);       // deep
+        const gen4 = place("generator", 14, 29);       // shallow
+        wireBuildings(gen4, trE);
+        wireBuildings(gen5, pduF);
+
+        // A BRIDGE THE WAVE ONLY PARTLY TAKES. upsF loses its own feed and
+        // bridges the whole 18 kW below it; the transfer switch then hands
+        // the 12 kW under pduG2 to a generator and LEAVES the 6 kW under
+        // pduH on the battery. The bridge is still up, so it still spends
+        // seconds — but the energy it hands over is 6 kW, not 18, and only
+        // this shape can tell those two numbers apart.
+        const feedF = place("grid_feed", 17, 27);
+        const upsF = place("ups", 20, 27);
+        const trF = place("transformer", 23, 27);
+        const pduG2 = place("pdu", 26, 27);
+        const pduH = place("pdu", 29, 27);
+        wireBuildings(feedF, upsF);
+        wireBuildings(upsF, trF);
+        wireBuildings(trF, pduG2);
+        wireBuildings(trF, pduH);
+        for (let i = 0; i < 2; i++) wireBuildings(pduG2, place("rack", 26, 28 + i));
+        wireBuildings(pduH, place("rack", 29, 28));
+        const gen6 = place("generator", 17, 29);
+        wireBuildings(gen6, pduG2);
+
+        return {
+            upsA, upsB, upsC, upsD, upsE, upsF,
+            gen, gen2, gen3, gen4, gen5, gen6,
+            pduB, trC, armed: false,
+        };
     }
 
     // The player's hand on the toggle and the city's hand on the meter. The
@@ -1182,5 +1416,298 @@ describe("THE LEDGER: a credited kW.s came out of a battery, or it did not happe
         // The two books never disagree, so `restored` is read exactly and the
         // invariant above carries no slack for a bug to hide in.
         expect(seen.nameplateRefills).toBe(0);
+    });
+
+    // ---- THE OTHER THREE BOOKS ------------------------------------------
+    // The two invariants above watch the battery credit. Three more pairs of
+    // numbers describe one physical quantity each, and each pair has been
+    // caught disagreeing: the fuel a generator burns against the kW it
+    // carries, the energy a bridge books against the energy it handed over,
+    // and the kW the meter charges against the kW a utility delivered. They
+    // are asserted here, on the same all-hazards run, because a room with
+    // one hazard in it is how the first six of these shipped.
+
+    // What every LIVE ROOT put out this tick. A grid feed's actualKw is its
+    // carry; a dark one carries nothing and neither does an empty generator.
+    function rootOutput() {
+        let feeds = 0;
+        let gens = 0;
+        for (const b of STATE.buildings) {
+            if (b.config.chainRole !== "source") continue;
+            if (b.type === "generator") gens += Math.max(0, b.actualKw);
+            else if (!feedIsDark(b)) feeds += Math.max(0, b.actualKw);
+        }
+        return { feeds, gens };
+    }
+
+    const byId = (id) => STATE.buildings.find((b) => b.id === id) || null;
+
+    function subtreeOf(node) {
+        const out = [];
+        const stack = [...node.childIds];
+        while (stack.length) {
+            const k = byId(stack.pop());
+            if (!k) continue;
+            out.push(k);
+            stack.push(...k.childIds);
+        }
+        return out;
+    }
+
+    // A charging UPS's draw, recovered from the ENERGY that landed in it
+    // rather than from any carried-kW field: restored = draw * eff * dt is
+    // the module's own definition, so inverting it gives the charger back
+    // without asking a link what it thinks it is carrying.
+    function chargerKwOf(u, before) {
+        const was = before.get(u.id);
+        const byCharge = (u.bufferLeft - was.sec) * (u.config.capacityKw || 0);
+        const byDebt = was.owed - u.bufferOwedKws;
+        const landed = Math.max(0, Math.min(byCharge, byDebt));
+        return landed / ((u.config.roundTripEff || 1) * DT);
+    }
+
+    // What a bridging UPS is REALLY handing down, per UPS rather than pooled
+    // over the facility: the load its subtree actually drew, plus any charger
+    // running inside it, MINUS whatever a closed transfer switch inside that
+    // subtree is carrying instead. Pooling this across the whole room leaves
+    // standing slack — the peak-shaved kW of some unrelated room is sourced
+    // from a battery and still carried by the feed above it, and a pooled
+    // ceiling has to allow for that, which is exactly the room an inflated
+    // bridge needs to hide in. Per UPS, nothing has to be allowed for.
+    function handedDownByBridge(ups, before) {
+        const under = subtreeOf(ups);
+        const inside = new Set(under.map((n) => n.id));
+        let sum = 0;
+        for (const n of under) {
+            if (n.config.chainRole === "load") sum += Math.max(0, n.actualKw);
+            else if (n.type === "ups") sum += chargerKwOf(n, before);
+        }
+        // A transfer switch that has actually closed is carrying its node,
+        // not the battery upstream of it. cutoverLeft === 0 is the switch
+        // being shut; before that the bridge is still feeding the node and
+        // the load below it must stay in the ceiling.
+        for (const n of STATE.buildings) {
+            if (!n.standbyParentId || !inside.has(n.id)) continue;
+            const g = byId(n.standbyParentId);
+            if (!g || g.actualKw <= 0 || g.cutoverLeft > 0) continue;
+            sum -= Math.max(0, n.actualKw);
+        }
+        return sum;
+    }
+
+    it("holds on EVERY tick: fuel burned, energy bridged, and kW billed each match what physically happened", () => {
+        const room = facility();
+        const seen = {
+            burning: 0, twoBurning: 0, bridging: 0, transferredBridge: 0,
+            metered: 0, darkTicks: 0, shaved: 0, nestedPair: 0,
+            fuelBurnedL: 0, genKwTicks: 0, billedKw: 0, feedKw: 0,
+        };
+        let brokeFuel = null;
+        let brokeBridge = null;
+        let brokeMeter = null;
+
+        for (let i = 0; i < Math.round(200 / DT); i++) {
+            STATE.elapsedGameTime += DT;
+            const t = STATE.elapsedGameTime;
+            script(t, room);
+            tickEvents(DT, t);
+            tickDemand(DT, t);
+
+            const before = books();
+            const tank = new Map();
+            for (const b of STATE.buildings) {
+                if (b.type === "generator") tank.set(b.id, b.fuelLiters);
+            }
+            resolvePower(DT);
+
+            // -- 1. FUEL BURNED vs kW CARRIED ---------------------------
+            // Per machine the burn follows its own carry exactly, and
+            // between them no two machines may carry the same load: the
+            // facility cannot draw less than its generators are burning
+            // diesel for. Two transfer switches in series used to bill two
+            // tanks for one set of racks, and which of them depended only on
+            // the order the buildings sat in STATE.buildings.
+            let genKw = 0;
+            let burning = 0;
+            for (const b of STATE.buildings) {
+                if (b.type !== "generator") continue;
+                genKw += Math.max(0, b.actualKw);
+                const burned = tank.get(b.id) - b.fuelLiters;
+                if (burned > 1e-12) burning++;
+                seen.fuelBurnedL += burned;
+                const expected = b.actualKw > 0
+                    ? Math.min(tank.get(b.id), b.actualKw * (DT / 60) * b.config.litersPerKwh)
+                    : 0;
+                if (Math.abs(burned - expected) > 1e-9 && brokeFuel === null) {
+                    brokeFuel = { atSec: +t.toFixed(2), why: "burn does not match carry", burned, expected, actualKw: b.actualKw };
+                }
+            }
+            if (genKw > STATE.totalDrawKw + 1e-9 && brokeFuel === null) {
+                brokeFuel = {
+                    atSec: +t.toFixed(2), why: "generators carry more than the facility drew",
+                    genKw, totalDrawKw: STATE.totalDrawKw,
+                };
+            }
+            seen.genKwTicks += genKw;
+            if (burning > 0) seen.burning++;
+            if (burning > 1) seen.twoBurning++;
+            // The two-switches-in-series branch really transferred: the
+            // SHALLOW machine is the one that must end up carrying, whichever
+            // order the two were placed in.
+            if (room.gen4.actualKw > 0) seen.nestedPair++;
+
+            // -- 2. bufferOwedKws vs ENERGY THAT ACTUALLY LEFT ----------
+            // A bridge may only book the load no live root is carrying. A
+            // generator picking up part of a bridged subtree means the
+            // battery never handed that part over — and the charger buys
+            // this exact figure back on the meter, so an inflated book is
+            // an inflated bill.
+            let bridging = 0;
+            for (const b of STATE.buildings) {
+                if (b.type !== "ups" || b.upsMode !== "bridging") continue;
+                bridging++;
+                const booked = b.bufferOwedKws - before.get(b.id).owed;
+                const ceilingKws = Math.max(0, handedDownByBridge(b, before)) * DT;
+                if (booked > ceilingKws + 1e-9 && brokeBridge === null) {
+                    brokeBridge = {
+                        atSec: +t.toFixed(2), ups: b.id, booked, ceilingKws,
+                        upsActualKw: b.actualKw, totalDrawKw: STATE.totalDrawKw,
+                    };
+                }
+            }
+            if (bridging > 0) seen.bridging++;
+            // THE shape this invariant exists for, named exactly rather than
+            // as "some generator somewhere was running": upsF is bridging
+            // and the transfer switch below it has taken part — not all — of
+            // what it was carrying.
+            if (room.upsF.upsMode === "bridging" && room.gen6.actualKw > 0) {
+                seen.transferredBridge++;
+            }
+
+            // -- 3. kW BILLED vs kW THAT CAME FROM A GRID FEED ----------
+            // The meter may never charge for more than the live feeds put
+            // out, and during a total blackout it may not charge at all —
+            // the generator already paid in fuel and the battery pays in the
+            // recharge, so billing them too is charging twice for energy no
+            // utility delivered.
+            const { feeds } = rootOutput();
+            const anyFeedLive = STATE.buildings.some(
+                (b) => b.type === "grid_feed" && !feedIsDark(b)
+            );
+            if (STATE.gridKw > feeds + 1e-9 && brokeMeter === null) {
+                brokeMeter = { atSec: +t.toFixed(2), why: "billed more than the feeds delivered", gridKw: STATE.gridKw, feeds };
+            }
+            if (!anyFeedLive && STATE.gridKw > 1e-9 && brokeMeter === null) {
+                brokeMeter = { atSec: +t.toFixed(2), why: "billed during a total blackout", gridKw: STATE.gridKw, totalDrawKw: STATE.totalDrawKw };
+            }
+            if (STATE.gridKw > STATE.totalDrawKw + 1e-9 && brokeMeter === null) {
+                brokeMeter = { atSec: +t.toFixed(2), why: "billed more than the facility drew", gridKw: STATE.gridKw, totalDrawKw: STATE.totalDrawKw };
+            }
+            seen.billedKw += STATE.gridKw;
+            seen.feedKw += feeds;
+            if (STATE.gridKw > 1e-9) seen.metered++;
+            if (!anyFeedLive) seen.darkTicks++;
+            if (STATE.batteryKw > 1e-9) seen.shaved++;
+        }
+
+        expect(brokeFuel).toBe(null);
+        expect(brokeBridge).toBe(null);
+        expect(brokeMeter).toBe(null);
+
+        // ...and the run really did reach every shape each invariant is
+        // about, so green cannot mean the hazard never happened.
+        expect(seen.burning).toBeGreaterThan(200);        // generators carried, at length
+        expect(seen.twoBurning).toBeGreaterThan(0);       // and two of them at once
+        expect(seen.nestedPair).toBeGreaterThan(100);     // incl. two switches in series
+        expect(seen.fuelBurnedL).toBeGreaterThan(1);      // real diesel
+        expect(seen.bridging).toBeGreaterThan(0);         // buffers bridged
+        expect(seen.transferredBridge).toBeGreaterThan(0);// with a transfer alongside
+        expect(seen.darkTicks).toBeGreaterThan(100);      // a total blackout happened
+        expect(seen.metered).toBeGreaterThan(1000);       // and the meter ran the rest
+        expect(seen.shaved).toBeGreaterThan(200);         // through shaving too
+        // The meter charged strictly less than the facility drew, and
+        // strictly more than nothing — an invariant satisfied by billing
+        // zero would prove nothing at all.
+        expect(seen.billedKw).toBeGreaterThan(0);
+        expect(seen.billedKw).toBeLessThan(seen.feedKw + 1e-9);
+        expect(seen.genKwTicks).toBeGreaterThan(0);
+    });
+
+    // The invariant above proves STATE.gridKw is the honest quantity. This
+    // one proves it is the quantity the METER actually charges, which is a
+    // separate claim living in a separate module — and it reads the charge
+    // out of the player's money rather than restating demand.js's formula,
+    // because a test that restates the formula it is checking proves only
+    // that two copies of it agree.
+    //
+    // The trick: STATE.tariff multiplies the power line and NOTHING else
+    // (not water, not SLA, not revenue — that separation is the two_utilities
+    // lesson). Play the identical run twice, once with the multiplier at
+    // zero, and the difference in money IS the power bill, tick by tick.
+    it("THE METER: the money charged for power is the kW that came off a feed, and nothing else", () => {
+        const PRICE = CONFIG.economy.powerCostPerKwh;
+
+        function pass(zeroTariff) {
+            resetState();
+            resetBuildingIds();
+            pinSchedules();
+            const room = facility();
+            if (zeroTariff) {
+                STATE.tariff.active = true;
+                STATE.tariff.multiplier = 0;
+                STATE.tariff.endsAt = Infinity;
+            }
+            const deltas = [];
+            const gridKws = [];
+            for (let i = 0; i < Math.round(200 / DT); i++) {
+                STATE.elapsedGameTime += DT;
+                const t = STATE.elapsedGameTime;
+                script(t, room);
+                tickEvents(DT, t);
+                const before = STATE.money;
+                tickDemand(DT, t);
+                deltas.push(STATE.money - before);
+                resolvePower(DT);
+                gridKws.push(STATE.gridKw);
+            }
+            return { deltas, gridKws, gameOver: STATE.gameOver };
+        }
+
+        const paid = pass(false);
+        const free = pass(true);
+        // Both passes must have played the SAME run, or the subtraction is
+        // comparing two different facilities.
+        expect(paid.gameOver).toBe(null);
+        expect(free.gameOver).toBe(null);
+        expect(paid.gridKws).toEqual(free.gridKws);
+
+        let broke = null;
+        let chargedKws = 0;
+        let meteredTicks = 0;
+        let freeTicks = 0;
+        for (let i = 0; i < paid.deltas.length; i++) {
+            // What the utility took off the player this tick, in kW.
+            const chargedKw = (free.deltas[i] - paid.deltas[i]) / (PRICE * (DT / 60));
+            // tickDemand bills on the PREVIOUS tick's resolution — the
+            // one-tick lag documented in docs/ARCHITECTURE.md — so this
+            // tick's charge answers to the gridKw resolved last tick.
+            const owedKw = i === 0 ? 0 : paid.gridKws[i - 1];
+            if (Math.abs(chargedKw - owedKw) > 1e-6 && broke === null) {
+                broke = {
+                    atSec: +((i + 1) * DT).toFixed(2),
+                    chargedKw, kwFromAGridFeed: owedKw,
+                };
+            }
+            chargedKws += chargedKw * DT;
+            if (chargedKw > 1e-9) meteredTicks++;
+            if (chargedKw <= 1e-9 && owedKw <= 1e-9) freeTicks++;
+        }
+
+        expect(broke).toBe(null);
+        // The run really did both: pay a utility, and run stretches on
+        // diesel and stored charge paying it nothing.
+        expect(meteredTicks).toBeGreaterThan(1000);
+        expect(freeTicks).toBeGreaterThan(100);
+        expect(chargedKws).toBeGreaterThan(0);
     });
 });

--- a/tests/water.test.mjs
+++ b/tests/water.test.mjs
@@ -280,6 +280,7 @@ describe("water is money, on the meter, at the meter's scale", () => {
     it("…and the drought never touches power", () => {
         STATE.demandFixedKw = 0;
         STATE.totalDrawKw = 20;
+        STATE.gridKw = 20;                  // all of it off the utility feed
         STATE.water.litersPerHour = 0;
         const before = STATE.money;
         tickDemand(30, 0);
@@ -288,6 +289,7 @@ describe("water is money, on the meter, at the meter's scale", () => {
         fresh();
         STATE.demandFixedKw = 0;
         STATE.totalDrawKw = 20;
+        STATE.gridKw = 20;
         forceDrought();
         const before2 = STATE.money;
         tickDemand(30, 0);


### PR DESCRIPTION
560 → **570 tests**. Three defects of the class this codebase has now shipped nine of: **two numbers describing one physical quantity that disagree.**

**Two generators on nested standby burned fuel twice for the same racks.** `coveredByEarlierWave()` walks a candidate's parents looking for an already-redelivered node, so it only ever detected a candidate *below* an earlier wave. When the deeper generator's wave ran first, the shallower one was an *ancestor* of the redelivered set, the walk never saw it, and both delivered. Measured on one room: 20 s of blackout burned **0.85 L with the shallow generator placed first and 1.70 L with the deep one first — exactly 2.0x for the same 12 kW**, decided by nothing but `STATE.buildings` order. Now 0.85 L either way.

**A UPS above a standby transfer point was debited for load it never carried.** `bufferOwedKws` is documented as what actually left the battery, and it is exactly what the charger buys back on the meter — but phase 4 booked the whole *pre-transfer* subtree pull, and the standby wave then took part of that subtree onto a generator. Measured **144 kW.s booked against 84 kW.s that actually left — 1.71x over the bridge, 3.0x on the post-cutover ticks.** Now 84 against 84.

**The utility billed every kW during a blackout.** `batteryKw` is the peak-shaving credit only; `power.js` sets it to 0 for the outage bridge. So with every feed dark, the meter still charged utility rates on diesel kW and battery kW — energy no utility delivered, and which already pays for itself twice over in fuel and in the recharge. **$2.16 → $0.00 on a generator, $1.08 → $0.00 on a bridge.**

That last one is a *quantity*, not a flag: `STATE.gridKw`, banked per node from the topology the way the battery credit already is. "Grid" enters the model in exactly one place — a `grid_feed` that is not dark — which is why a **scoped** outage and a generator-fed room on a perfectly healthy grid both come out right, where an `if (gridOutage.active)` special case gets both wrong. The second case was being overcharged too, and is now also fixed: **$4.32 → $2.16** for half a room on a generator with nothing wrong with the grid.

**No campaign verdict moved.** Every objective margin is byte-identical across all thirteen pairs; only money moved, on `dark_chain` and `fuel_clock`, both of which were being overcharged. `two_utilities` and `night_shift` were predicted to move and did not — their rooms never draw off a battery or a generator, so they were already billed grid-sourced kW only.

**And the floor, not just the ceiling.** Every clause of the ledger invariant reads `x > y` — it catches charging too much and misses charging too little, which is free energy and the worse direction. Three topologies now pin the floor from below.

One defect found while pinning that floor is deliberately NOT fixed here: a bridge that runs its buffer to zero hands out one final tick it no longer has (carried 6 kW, booked 0). It is identical on `main`, so it is not this work, and it is written up rather than papered over.