### PR TITLE
A bridge handed out one tick of power it did not have — and the ledger gains its floor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ npm i
 npm run check     # eslint . && vitest run — exactly what CI runs
 ```
 
-Baseline today: lint clean, 33 test files, 570 tests, about 3 s. CI uses
+Baseline today: lint clean, 33 test files, 572 tests, about 3 s. CI uses
 Node 22. Nothing here downloads a browser: the demo recorder drives your
 system Chrome through `playwright-core`, which ships no binaries.
 
@@ -103,7 +103,7 @@ Never call `Math.random` in a sim module. Schedules use two sentinel values:
 "can never fire" (how a campaign level guarantees a deterministic script).
 
 **`resetState()` is hand-maintained.** Add a field to the `STATE` literal and
-forget `resetState()` and all 570 tests still pass — the field is silently
+forget `resetState()` and all 572 tests still pass — the field is silently
 deleted on the first reset. Call `resetBuildingIds()` alongside every
 `resetState()`, and `resetWireIds()` too if you use `src/sim/build.js`.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ real playthrough.
 ## Status
 
 Thirteen campaign levels across five chapters plus The Lab, nine buildings,
-570 tests. Simulation: wired power with inverse-time breakers, a diffusing
+572 tests. Simulation: wired power with inverse-time breakers, a diffusing
 heat field with part-load cooling, a shared chilled-water loop metered for
 water on a WUE, UPS buffers, standby generators with fuel, grid sags,
 per-substation outages, time-of-use and peak tariffs, droughts, peak shaving

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ elapsedGameTime += dt          (skipped while the tutorial is active)
 ```
 
 The order encodes causality. Nothing asserts it: the loop is hand-copied into
-17 test files, 50 copies in all, so reordering `game.js` leaves the whole
+17 test files, 54 copies in all, so reordering `game.js` leaves the whole
 suite green while the shipped game behaves differently. Those two numbers are
 themselves pinned by `tests/docs-counts.test.mjs` — they drifted four times
 before anyone noticed, which is the same argument this file makes for

--- a/src/sim/power.js
+++ b/src/sim/power.js
@@ -548,9 +548,10 @@ export function resolvePower(dt) {
                 // The ENERGY it really handed over is what the charger will
                 // have to buy back, so that is what gets recorded.
                 outLive = true;
-                outKw = subtreePull; // self-grant: serve the subtree from the buffer
+                // SECONDS first, because the grant now depends on how many of
+                // this tick's seconds the buffer can actually cover.
+                const drainedSec = Math.min(dt, b.bufferLeft);
                 if (subtreePull > 0) {
-                    const drainedSec = Math.min(dt, b.bufferLeft);
                     b.bufferLeft -= drainedSec;
                     // SECONDS now, ENERGY at 5c. Booking `subtreePull *
                     // drainedSec` here charges the battery for the whole
@@ -561,6 +562,21 @@ export function resolvePower(dt) {
                     // the meter.
                     bridgeDrain.set(b.id, drainedSec);
                 }
+                // A buffer with 4 ms left in it cannot power a 50 ms tick.
+                // The branch above is entered on `bufferLeft > 0` however
+                // little is left, and used to grant the whole subtree pull
+                // for the whole tick regardless — so the last tick of every
+                // bridge handed the room a full tick of power on a sliver of
+                // battery, and the difference was energy no source produced.
+                //
+                // On every full tick drainedSec === dt and this is exactly
+                // subtreePull, byte for byte. Only the tick that empties the
+                // buffer is scaled, and it is scaled to the tick-AVERAGE
+                // rate, so the energy delivered across the tick (outKw * dt)
+                // is exactly subtreePull * drainedSec: the energy that really
+                // left. Peak shaving has capped its grant by the charge left
+                // since the day it was written; the bridge never did.
+                outKw = subtreePull * (drainedSec / dt);
                 outBattKw = 0; // bridged load is not peak shaving; see demand.js
                 outGridKw = 0; // ...and it is the battery, not the meter
                 carriedKw = outKw;
@@ -871,13 +887,19 @@ export function resolvePower(dt) {
     // Two different quantities, and only the second one may follow the load —
     // booking it against the pre-transfer subtree pull up in deliver() is how
     // one physical discharge ended up with two numbers describing it.
-    for (const [id, drainedSec] of bridgeDrain) {
+    for (const id of bridgeDrain.keys()) {
         const b = byId.get(id);
         // Still bridging: a UPS the wave re-delivered took the live branch on
         // its second pass and had its buffer rolled back to the snapshot, so
         // there is no discharge left to book.
         if (!b || b.upsMode !== "bridging") continue;
-        b.bufferOwedKws += Math.max(0, b.actualKw) * drainedSec;
+        // dt, not the drained seconds: actualKw is the tick-AVERAGE rate now
+        // that the grant is capped by the charge left, so rate * dt is the
+        // energy. On a full tick the two forms are identical (drainedSec ===
+        // dt); on the tick that empties the buffer, multiplying the already
+        // scaled rate by the sliver again would book the sliver twice and
+        // under-charge the charger for a discharge that did happen.
+        b.bufferOwedKws += Math.max(0, b.actualKw) * dt;
     }
 
     // 6) Fuel burn (billing scale: one game minute = one billing hour) and

--- a/tests/peak-shaving.test.mjs
+++ b/tests/peak-shaving.test.mjs
@@ -1579,6 +1579,7 @@ describe("THE LEDGER: a credited kW.s came out of a battery, or it did not happe
         let brokeFuel = null;
         let brokeBridge = null;
         let brokeMeter = null;
+        const owedBefore = new Map();
 
         for (let i = 0; i < Math.round(200 / DT); i++) {
             STATE.elapsedGameTime += DT;
@@ -1664,7 +1665,7 @@ describe("THE LEDGER: a credited kW.s came out of a battery, or it did not happe
             // the generator already paid in fuel and the battery pays in the
             // recharge, so billing them too is charging twice for energy no
             // utility delivered.
-            const { feeds } = rootOutput();
+            const { feeds, gens } = rootOutput();
             const anyFeedLive = STATE.buildings.some(
                 (b) => b.type === "grid_feed" && !feedIsDark(b)
             );
@@ -1676,6 +1677,40 @@ describe("THE LEDGER: a credited kW.s came out of a battery, or it did not happe
             }
             if (STATE.gridKw > STATE.totalDrawKw + 1e-9 && brokeMeter === null) {
                 brokeMeter = { atSec: +t.toFixed(2), why: "billed more than the facility drew", gridKw: STATE.gridKw, totalDrawKw: STATE.totalDrawKw };
+            }
+            // ...AND THE FLOOR, which is the dangerous side. The three
+            // clauses above all read `gridKw > x`: they catch a meter that
+            // charges too much, which is unfair, and say nothing about one
+            // that charges too little — which is FREE ENERGY, and worse.
+            //
+            // Every kW the facility drew came off a feed, out of a generator,
+            // or out of a battery, and the battery leaves through exactly two
+            // doors: peak shaving (STATE.batteryKw) and the outage bridge,
+            // which batteryKw deliberately does not count. bufferOwedKws is
+            // the bridge's own meter of what left, so the residual is closed
+            // with that measurement rather than a second guess at it. Only
+            // the RISING side per buffer: owed falls when the charger buys
+            // the energy back, and that recharge is already in totalDrawKw as
+            // charger draw and already billed.
+            //
+            // This clause could not be written until the bridge stopped
+            // handing out a final tick it did not have — it fired on the
+            // exhaustion tick, which is exactly what it is for.
+            let bridgeKw = 0;
+            for (const b of STATE.buildings) {
+                if (!("bufferOwedKws" in b)) continue;
+                const prev = owedBefore.get(b.id) || 0;
+                const now = b.bufferOwedKws || 0;
+                if (now > prev) bridgeKw += (now - prev) / DT;
+                owedBefore.set(b.id, now);
+            }
+            const offMeter = STATE.totalDrawKw - STATE.batteryKw - gens - bridgeKw;
+            if (STATE.gridKw < offMeter - 1e-6 && brokeMeter === null) {
+                brokeMeter = {
+                    atSec: +t.toFixed(2), why: "drew kW that nothing paid for",
+                    gridKw: STATE.gridKw, owed: offMeter, bridgeKw,
+                    totalDrawKw: STATE.totalDrawKw, batteryKw: STATE.batteryKw, gens,
+                };
             }
             seen.billedKw += STATE.gridKw;
             seen.feedKw += feeds;
@@ -1783,5 +1818,78 @@ describe("THE LEDGER: a credited kW.s came out of a battery, or it did not happe
         expect(meteredTicks).toBeGreaterThan(1000);
         expect(freeTicks).toBeGreaterThan(100);
         expect(chargedKws).toBeGreaterThan(0);
+    });
+});
+
+describe("a bridge cannot hand out energy it does not have", () => {
+    // bufferLeft counts SECONDS at the UPS's full rating — that is the
+    // ride-through model every campaign level is proven against and it is
+    // deliberately untouched here. What was wrong is the kW handed DOWN on
+    // the tick that empties the buffer: the branch is entered on
+    // `bufferLeft > 0`, however little is left, and then grants the whole
+    // subtree pull for the whole tick. A buffer with 4 ms left powered a
+    // 50 ms tick, and the difference is energy no source produced.
+    it("THE LAST TICK: what it carries matches what left the battery, every tick", () => {
+        const { ups, pdu } = chain();
+        const racks = [];
+        for (let i = 0; i < 1; i++) {
+            const r = place("rack", 14 + i, 5);
+            wireBuildings(pdu, r);
+            r.assignedKw = CONFIG.buildings.rack.capacityKw;
+            racks.push(r);
+        }
+        STATE.demandFixedKw = racks.length * CONFIG.buildings.rack.capacityKw;
+        for (let k = 0; k < 40; k++) resolvePower(DT);          // charge up
+        expect(ups.bufferLeft).toBeGreaterThan(0);
+
+        STATE.gridOutage = { active: true, endsAt: 1e9, nextAt: Infinity, scope: "all" };
+
+        let worst = null;
+        let bridgingTicks = 0;
+        let prevOwed = ups.bufferOwedKws || 0;
+        for (let k = 0; k < 4000; k++) {
+            resolvePower(DT);
+            const owed = ups.bufferOwedKws || 0;
+            const bookedKw = (owed - prevOwed) / DT;
+            prevOwed = owed;
+            if (ups.upsMode !== "bridging" || ups.actualKw <= 1e-9) continue;
+            bridgingTicks++;
+            const gap = ups.actualKw - bookedKw;
+            if (worst === null || gap > worst.gap) {
+                worst = {
+                    tick: k, gap: +gap.toFixed(6),
+                    carriedKw: ups.actualKw, bookedKw: +bookedKw.toFixed(6),
+                    bufferLeft: ups.bufferLeft,
+                };
+            }
+        }
+        // The run really did bridge, and to exhaustion, or this proves nothing.
+        expect(bridgingTicks).toBeGreaterThan(100);
+        expect(ups.bufferLeft).toBeCloseTo(0, 9);
+        // Every tick, including the one that empties it.
+        expect(worst.gap, `carried more than left the battery: ${JSON.stringify(worst)}`)
+            .toBeLessThan(1e-9);
+    });
+
+    it("...and the seconds are still spent at full rating — the ride-through is unchanged", () => {
+        // The fix must not buy honesty by shortening the bridge: how long a
+        // UPS holds a room is the number the campaign levels are balanced on.
+        const { ups, pdu } = chain();
+        const r = place("rack", 14, 5);
+        wireBuildings(pdu, r);
+        r.assignedKw = CONFIG.buildings.rack.capacityKw;
+        STATE.demandFixedKw = CONFIG.buildings.rack.capacityKw;
+        for (let k = 0; k < 40; k++) resolvePower(DT);
+        const full = ups.bufferLeft;
+        expect(full).toBeCloseTo(U.bufferSec, 6);
+
+        STATE.gridOutage = { active: true, endsAt: 1e9, nextAt: Infinity, scope: "all" };
+        let held = 0;
+        for (let k = 0; k < 4000 && ups.bufferLeft > 0; k++) {
+            resolvePower(DT);
+            if (ups.upsMode === "bridging") held += DT;
+        }
+        // Seconds spent at the rating, not at the load: the whole buffer.
+        expect(held).toBeCloseTo(U.bufferSec, 1);
     });
 });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -23,6 +23,15 @@ export default defineConfig({
           environment: "happy-dom",
           include: ["tests/sim/*.test.mjs"],
           setupFiles: ["tests/helpers/sim-setup.mjs"],
+          // These tests PLAY the game — the economics pair below runs four
+          // full timed sessions and takes ~2.3 s on an idle machine and over
+          // 5 s when the rest of the suite is running beside it. Vitest's
+          // default is 5 s, which is a default and not a budget anyone chose
+          // for a suite like this, so the slowest honest test sat a busy CI
+          // runner away from a spurious red. 20 s still catches a genuine
+          // hang, which is the only thing a timeout is for here: nothing in
+          // these tests waits on IO, a timer or a clock.
+          testTimeout: 20000,
         },
       },
     ],


### PR DESCRIPTION
Closes #31. 570 → **572 tests**.

## The defect

The outage bridge is entered on `bufferLeft > 0` — however little is left — and then grants the whole subtree pull for the whole tick:

```js
} else if (b.bufferLeft > 0) {
    outKw = subtreePull;                              // the whole tick
    const drainedSec = Math.min(dt, b.bufferLeft);    // ...a sliver of battery
```

A buffer with 4 ms left in it powered a 50 ms tick. Measured on one bridge run to exhaustion: **161 bridging ticks, 160 of them booking exactly what they carry, and the last one carrying 6 kW while booking 0.**

Small in absolute terms, and exactly the class `tests/peak-shaving.test.mjs` exists to prevent: energy the facility used that no source produced.

Peak shaving has capped its grant by the charge left since the day it was written — *"THE GRANT IS CAPPED BY THE CHARGE LEFT: a sliver of battery shaves a sliver, the grid carries the rest."* The bridge never did.

## The fix

`outKw = subtreePull * (drainedSec / dt)` — the tick-**average** rate, so the energy delivered across the tick is exactly `subtreePull * drainedSec`: the energy that really left. The booking moves from `drainedSec` to `dt` to stay consistent with a rate that is now an average rather than a peak.

**What is deliberately not changed**: `bufferLeft` still counts SECONDS spent at the UPS's full rating however little it carries. That is the ride-through model every campaign level is balanced against, and there is now a test pinning it, so the next person cannot buy honesty by shortening the bridge.

**On campaign safety.** Both expressions differ from the old ones only when `drainedSec < dt`, which is exactly when `bufferLeft < dt` — the single tick that empties a buffer. On every other tick they are identical by arithmetic, not by approximation. And a level that is *won* by a UPS carrying an outage does not reach that tick by definition: a buffer that empties is the LOSE case. All 13 machine-played pairs pass.

## The payoff

**The ledger invariant gains its floor.** Its three meter clauses all read `gridKw > x` — they catch a meter charging too much, which is unfair, and say nothing about one charging too little, which is free energy and worse. I wrote that fourth clause last night and could not ship it: this defect fired it on the exhaustion tick, and I filed #31 rather than widen a tolerance until it passed.

It now holds across the whole chaotic run — outages, brownouts, trips, both generators, the toggle flipping — and the conservation class is closed from both sides.

## One thing found on the way

An explicit `testTimeout` for the `sim` project. `THE PAIR` plays four full timed sessions: 2.3 s on an idle machine, **over 5 s when the rest of the suite runs beside it**. Vitest's default is 5 s — a default, not a budget anyone chose for a suite that plays whole games — so the slowest honest test in the repo sat one busy CI runner away from a spurious red. Reproduced at 1 failure in 16 full runs before the change, 0 in 11 after. 20 s still catches a real hang, which is the only thing a timeout is for here: nothing in these tests waits on IO, a timer, or a clock.

## Mutation checks

Reverting the fix to the true original code (full grant **and** booking by drained seconds) turns red exactly the two tests that should die: the targeted last-tick test, and the ledger invariant's new floor clause. Halving the booking kills four. Reverting only half the change produces a *different* bug — an over-booking — and the suite catches that too.